### PR TITLE
REST 2.27 Support: nsid and deprecate Snap2NFS

### DIFF
--- a/changelogs/fragments/499_rest_227.yaml
+++ b/changelogs/fragments/499_rest_227.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+ - purefa_info - Add NSID value for NVMe namespace in `hosts` response
+ - purefa_offload - Remove `nfs` as an option when Purity//FA 6.6.0 or higher is detected

--- a/plugins/modules/purefa_offload.py
+++ b/plugins/modules/purefa_offload.py
@@ -40,6 +40,7 @@ options:
   protocol:
     description:
     - Define which protocol the offload engine uses
+    - NFS is not a supported protocl from Purity//FA 6.6.0 and higher
     default: nfs
     choices: [ nfs, s3, azure, gcp ]
     type: str
@@ -176,6 +177,7 @@ GCP_API_VERSION = "2.3"
 MULTIOFFLOAD_API_VERSION = "2.11"
 MULTIOFFLOAD_LIMIT = 5
 PROFILE_API_VERSION = "2.25"
+NO_SNAP2NFS_VERSION = "2.27"
 
 
 def get_target(module, array):
@@ -448,6 +450,10 @@ def main():
     array = get_system(module)
     api_version = array._list_available_rest_versions()
 
+    if NO_SNAP2NFS_VERSION in api_version and module.params["protocol"] == "nfs":
+        module.fail_json(
+            msg="NFS offload target is not supported from Purity//FA 6.6.0 and higher"
+        )
     if (
         (
             module.params["protocol"].lower() == "azure"


### PR DESCRIPTION
##### SUMMARY
REST 2.27 (Purirty//FA 6.6.0) add `nsid` as  a value for volume host connections and deprecates support for Snap2NFS, ie remove 'nfs' as an offload target.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefa_info.py
purefa_offload.py