### PR TITLE
Add suffix support for offload snapshots

### DIFF
--- a/changelogs/fragments/513_remote_snapshot_suffix.yaml
+++ b/changelogs/fragments/513_remote_snapshot_suffix.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - purefa_snap - Add support for suffix on remote offload snapshots


### PR DESCRIPTION
##### SUMMARY
Add support for `suffix` to be specified for remote offload snapshots.

##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
purefa_snap.py