### PR TITLE
Fix issue with pod deletion

### DIFF
--- a/changelogs/fragments/638_delete_pod.yaml
+++ b/changelogs/fragments/638_delete_pod.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefa_pod - Allow pd to be deleted with contents if ``delete_contents`` specified

--- a/plugins/modules/purefa_pod.py
+++ b/plugins/modules/purefa_pod.py
@@ -625,7 +625,9 @@ def delete_pod(module, array):
     changed = True
     if not module.check_mode:
         res = array.patch_pods(
-            names=[module.params["name"]], pod=PodPatch(destroyed=True)
+            names=[module.params["name"]],
+            pod=PodPatch(destroyed=True),
+            delete_contents=module.params["delete_contents"],
         )
         if res.status_code != 200:
             module.fail_json(


### PR DESCRIPTION
##### SUMMARY
Fixed an issue where a pod cannot be deleted if it has contents even if `delete_contents` was specified.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_pod.py