### PR TITLE
purefa_pod: add realm parameter for realm membership

### DIFF
--- a/changelogs/fragments/1021_purefa_pod_realm.yaml
+++ b/changelogs/fragments/1021_purefa_pod_realm.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - purefa_pod - Add ``realm`` parameter to place a pod inside a realm without having to hand-craft the ``realm::pod`` name

--- a/plugins/modules/purefa_pod.py
+++ b/plugins/modules/purefa_pod.py
@@ -27,8 +27,21 @@ options:
   name:
     description:
     - The name of the pod.
+    - To place a pod inside a realm either set the I(realm) parameter, or
+      provide the fully-qualified C(realm::pod) name here (for example
+      C(myrealm::mypod)). If I(realm) is set, do not also use the C(::)
+      form in this parameter.
     type: str
     required: true
+  realm:
+    description:
+    - Name of the realm the pod belongs to.
+    - When set, the pod is created (or managed) as C(realm::pod). This is a
+      convenience for the C(realm::pod) naming convention and is mutually
+      exclusive with providing C(::) directly in I(name).
+    - Requires Purity//FA 6.6.11, or higher (REST 2.36).
+    type: str
+    version_added: '1.44.0'
   stretch:
     description:
     - The name of the array to stretch to/unstretch from. Must be synchromously replicated.
@@ -159,6 +172,14 @@ EXAMPLES = r"""
     api_token: e31060a7-21fc-e277-6240-25983c6c4592
     state: present
 
+- name: Create new pod bar inside realm myrealm
+  purestorage.flasharray.purefa_pod:
+    name: bar
+    realm: myrealm
+    fa_url: 10.10.10.2
+    api_token: e31060a7-21fc-e277-6240-25983c6c4592
+    state: present
+
 - name: Create new pod named foo with default protection PG safe, and with PG retention lock disabled
   purestorage.flasharray.purefa_pod:
     name: foo
@@ -255,6 +276,7 @@ DEFAULT_API_VERSION = "2.16"
 POD_QUOTA_VERSION = "2.23"
 THROTTLE_VERSION = "2.31"
 MEMBERS_VERSION = "2.36"
+REALM_VERSION = "2.36"
 CONTEXT_VERSION = "2.38"
 
 
@@ -1050,6 +1072,7 @@ def main():
     argument_spec.update(
         dict(
             name=dict(type="str", required=True),
+            realm=dict(type="str"),
             stretch=dict(type="str"),
             target=dict(type="str"),
             mediator=dict(type="str", default="purestorage"),
@@ -1086,6 +1109,18 @@ def main():
 
     state = module.params["state"]
     array = get_array(module)
+
+    if module.params.get("realm"):
+        if LooseVersion(REALM_VERSION) > LooseVersion(array.get_rest_version()):
+            module.fail_json(
+                msg="realm parameter requires Purity//FA 6.6.11, or higher (REST 2.36)."
+            )
+        if "::" in module.params["name"]:
+            module.fail_json(
+                msg="Use either the 'realm' parameter or the 'realm::pod' "
+                "form in 'name', not both."
+            )
+        module.params["name"] = module.params["realm"] + "::" + module.params["name"]
 
     pod = get_pod(module, array)
     destroyed = ""

--- a/tests/unit/plugins/modules/test_purefa_pod.py
+++ b/tests/unit/plugins/modules/test_purefa_pod.py
@@ -2450,6 +2450,135 @@ class TestMain:
             main()
             mock_create.assert_called_once()
 
+    @patch("plugins.modules.purefa_pod.LooseVersion", side_effect=LooseVersion)
+    @patch("plugins.modules.purefa_pod.HAS_PURESTORAGE", True)
+    @patch("plugins.modules.purefa_pod.get_array")
+    @patch("plugins.modules.purefa_pod.get_pod")
+    @patch("plugins.modules.purefa_pod.get_destroyed_pod")
+    @patch("plugins.modules.purefa_pod.check_arrays")
+    @patch("plugins.modules.purefa_pod.AnsibleModule")
+    def test_main_realm_composes_name(
+        self,
+        mock_ansible,
+        mock_check_arrays,
+        mock_get_destroyed_pod,
+        mock_get_pod,
+        mock_get_array,
+        mock_lv,
+    ):
+        """realm parameter composes the realm::pod name (#pod-realm)"""
+        from plugins.modules.purefa_pod import main
+
+        mock_module = Mock()
+        mock_module.params = {
+            "name": "bar",
+            "realm": "myrealm",
+            "state": "present",
+            "stretch": None,
+            "target": None,
+            "failover": None,
+            "mediator": "purestorage",
+            "context": "",
+        }
+        mock_ansible.return_value = mock_module
+        mock_array = Mock()
+        mock_array.get_rest_version.return_value = "2.39"
+        mock_get_array.return_value = mock_array
+        mock_get_pod.return_value = False
+        mock_get_destroyed_pod.return_value = False
+
+        with patch("plugins.modules.purefa_pod.create_pod") as mock_create:
+            main()
+            mock_create.assert_called_once()
+
+        assert mock_module.params["name"] == "myrealm::bar"
+
+    @patch("plugins.modules.purefa_pod.LooseVersion", side_effect=LooseVersion)
+    @patch("plugins.modules.purefa_pod.HAS_PURESTORAGE", True)
+    @patch("plugins.modules.purefa_pod.get_array")
+    @patch("plugins.modules.purefa_pod.get_pod")
+    @patch("plugins.modules.purefa_pod.get_destroyed_pod")
+    @patch("plugins.modules.purefa_pod.check_arrays")
+    @patch("plugins.modules.purefa_pod.AnsibleModule")
+    def test_main_realm_conflicts_with_name_separator(
+        self,
+        mock_ansible,
+        mock_check_arrays,
+        mock_get_destroyed_pod,
+        mock_get_pod,
+        mock_get_array,
+        mock_lv,
+    ):
+        """realm plus a '::' name is rejected (#pod-realm)"""
+        import pytest
+        from plugins.modules.purefa_pod import main
+
+        mock_module = Mock()
+        mock_module.params = {
+            "name": "already::there",
+            "realm": "myrealm",
+            "state": "present",
+            "stretch": None,
+            "target": None,
+            "failover": None,
+            "mediator": "purestorage",
+            "context": "",
+        }
+        mock_module.fail_json.side_effect = SystemExit(1)
+        mock_ansible.return_value = mock_module
+        mock_array = Mock()
+        mock_array.get_rest_version.return_value = "2.39"
+        mock_get_array.return_value = mock_array
+
+        with pytest.raises(SystemExit):
+            main()
+
+        mock_module.fail_json.assert_called_once()
+        assert "not both" in str(mock_module.fail_json.call_args)
+
+    @patch("plugins.modules.purefa_pod.LooseVersion", side_effect=LooseVersion)
+    @patch("plugins.modules.purefa_pod.HAS_PURESTORAGE", True)
+    @patch("plugins.modules.purefa_pod.get_array")
+    @patch("plugins.modules.purefa_pod.get_pod")
+    @patch("plugins.modules.purefa_pod.get_destroyed_pod")
+    @patch("plugins.modules.purefa_pod.check_arrays")
+    @patch("plugins.modules.purefa_pod.AnsibleModule")
+    def test_main_realm_requires_supported_api(
+        self,
+        mock_ansible,
+        mock_check_arrays,
+        mock_get_destroyed_pod,
+        mock_get_pod,
+        mock_get_array,
+        mock_lv,
+    ):
+        """realm on a pre-2.36 array is rejected (#pod-realm)"""
+        import pytest
+        from plugins.modules.purefa_pod import main
+
+        mock_module = Mock()
+        mock_module.params = {
+            "name": "bar",
+            "realm": "myrealm",
+            "state": "present",
+            "stretch": None,
+            "target": None,
+            "failover": None,
+            "mediator": "purestorage",
+            "context": "",
+        }
+        mock_module.fail_json.side_effect = SystemExit(1)
+        mock_ansible.return_value = mock_module
+        mock_array = Mock()
+        mock_array.get_rest_version.return_value = "2.30"
+        mock_get_array.return_value = mock_array
+
+        with pytest.raises(SystemExit):
+            main()
+
+        mock_module.fail_json.assert_called_once()
+        assert "2.36" in str(mock_module.fail_json.call_args)
+
     @patch("plugins.modules.purefa_pod.HAS_PURESTORAGE", True)
     @patch("plugins.modules.purefa_pod.get_array")
     @patch("plugins.modules.purefa_pod.get_pod")


### PR DESCRIPTION
##### SUMMARY
Placing a pod inside a realm previously required hand-crafting the realm::pod name string, which is only discoverable from the CLI convention. Add a realm parameter that composes the realm::pod name internally.

realm is mutually exclusive with providing the :: form directly in name, and requires REST 2.36 or higher (realms support). The name option docs now also describe the realm::pod convention for discoverability.

Tests: added coverage for name composition, the realm/:: conflict, and the minimum API version guard.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefa_pod.py