### PR TITLE
purefa_policy - handle null password-policy fields and gate max_password_age

### DIFF
--- a/changelogs/fragments/1031_purefa_policy_password_null.yaml
+++ b/changelogs/fragments/1031_purefa_policy_password_null.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - purefa_policy - Fix AttributeError updating a password policy when the array returns null for fields such as ``lockout_duration``, by reading them safely and treating null as not configured
+  - purefa_policy - Gate ``max_password_age`` behind FlashArray REST API 2.39, the version that introduced it, so a clear error is returned instead of an unsupported-field failure on older arrays

--- a/plugins/modules/purefa_policy.py
+++ b/plugins/modules/purefa_policy.py
@@ -260,6 +260,7 @@ options:
     - Supported time units are C(w) (weeks), C(d) (days), C(h) (hours), C(m) (minutes), C(s) (seconds).
     - Range between 1 day and 99999 days.
     - A value of 0 or C(0s) disables password expiration.
+    - Requires FlashArray REST API 2.39 or later.
     type: str
     version_added: 1.33.0
   rule_name:
@@ -526,6 +527,7 @@ SECURITY_VERSION = "2.29"
 ABE_VERSION = "2.4"
 PASSWORD_VERSION = "2.34"
 CONTEXT_VERSION = "2.38"
+MAX_PASSWORD_AGE_VERSION = "2.39"
 CA_VERSION = "2.43"
 
 
@@ -2002,12 +2004,24 @@ def update_policy(module, array, api_version, all_squash):
         )
         pwd_policy = list(res.items)[0]
         current_pwd_policy = {
-            "enforce_dictionary_check": pwd_policy.enforce_dictionary_check,
-            "enforce_username_check": pwd_policy.enforce_username_check,
-            "lockout_duration": pwd_policy.lockout_duration,
-            "min_character_groups": pwd_policy.min_character_groups,
-            "min_characters_per_group": pwd_policy.min_characters_per_group,
-            "min_password_length": pwd_policy.min_password_length,
+            # These fields can be returned as null (for example lockout_duration
+            # on a management policy that has never had it set). The pydantic
+            # models in newer py-pure-client raise AttributeError on direct
+            # access to an unset field, so use getattr and treat null as "not
+            # configured" - a None here differs from any requested value, so a
+            # supplied setting is still applied.
+            "enforce_dictionary_check": getattr(
+                pwd_policy, "enforce_dictionary_check", None
+            ),
+            "enforce_username_check": getattr(
+                pwd_policy, "enforce_username_check", None
+            ),
+            "lockout_duration": getattr(pwd_policy, "lockout_duration", None),
+            "min_character_groups": getattr(pwd_policy, "min_character_groups", None),
+            "min_characters_per_group": getattr(
+                pwd_policy, "min_characters_per_group", None
+            ),
+            "min_password_length": getattr(pwd_policy, "min_password_length", None),
             "min_password_age": getattr(pwd_policy, "min_password_age", 0),
             "max_password_age": getattr(pwd_policy, "max_password_age", 0),
             "max_login_attempts": getattr(pwd_policy, "max_login_attempts", 0),
@@ -2493,6 +2507,17 @@ def main():
         module.fail_json(
             msg="FlashArray REST version not supported for password policies. "
             "Minimum version required: {0}".format(PASSWORD_VERSION)
+        )
+    if (
+        module.params["policy"] == "password"
+        and module.params["max_password_age"]
+        and LooseVersion(MAX_PASSWORD_AGE_VERSION) > LooseVersion(api_version)
+    ):
+        module.fail_json(
+            msg="FlashArray REST version not supported for max_password_age in "
+            "password policies. Minimum version required: {0}".format(
+                MAX_PASSWORD_AGE_VERSION
+            )
         )
     if (
         module.params["policy"] == "password"

--- a/tests/unit/plugins/modules/test_purefa_policy.py
+++ b/tests/unit/plugins/modules/test_purefa_policy.py
@@ -91,6 +91,7 @@ from plugins.modules.purefa_policy import (
     rename_policy,
     create_policy,
     update_policy,
+    main,
 )
 
 
@@ -4142,6 +4143,78 @@ class TestUpdatePasswordPolicyBugFixes:
         assert call_kwargs["min_character_groups"] == 2
         mock_module.exit_json.assert_called_once_with(changed=True)
 
+    @patch("plugins.modules.purefa_policy.check_response")
+    @patch("plugins.modules.purefa_policy.patch_with_context")
+    @patch("plugins.modules.purefa_policy.get_with_context")
+    @patch("plugins.modules.purefa_policy.LooseVersion", side_effect=LooseVersion)
+    @patch("plugins.modules.purefa_policy.PolicyPassword")
+    def test_update_password_policy_null_fields(
+        self, mock_pwd, mock_lv, mock_get, mock_patch, mock_check
+    ):
+        """Null password-policy fields must not raise AttributeError (issue #1030).
+
+        A management policy can return null for fields such as lockout_duration.
+        The pydantic models in newer py-pure-client raise AttributeError on
+        direct access to an unset field, so the module must use getattr and
+        treat null as "not configured".
+        """
+        mock_module = Mock()
+        mock_module.params = {
+            "name": "management",
+            "policy": "password",
+            "enabled": True,
+            "enforce_dictionary_check": True,
+            "enforce_username_check": True,
+            "min_character_groups": 4,
+            "min_characters_per_group": 1,
+            "min_password_length": 14,
+            "min_password_age": None,
+            "max_password_age": None,
+            "max_login_attempts": 5,
+            "lockout_duration": 900,
+            "password_history": 24,
+            "directory": None,
+            "context": "",
+        }
+        mock_module.check_mode = False
+        mock_array = Mock()
+        mock_array.get_rest_version.return_value = "2.38"
+
+        # spec omits the six nullable fields, so direct attribute access on
+        # them raises AttributeError - mirroring the pydantic SDK returning
+        # null - and getattr(..., None) is the only safe way to read them.
+        mock_policy = Mock(
+            spec=[
+                "enabled",
+                "min_password_age",
+                "max_password_age",
+                "max_login_attempts",
+                "password_history",
+            ]
+        )
+        mock_policy.enabled = True
+        mock_policy.min_password_age = 0
+        mock_policy.max_password_age = 0
+        mock_policy.max_login_attempts = 5
+        mock_policy.password_history = 0
+
+        mock_get.return_value = Mock(status_code=200, items=[mock_policy])
+        mock_patch.return_value = Mock(status_code=200)
+
+        update_policy(mock_module, mock_array, "2.38", False)
+
+        mock_pwd.assert_called_once()
+        call_kwargs = mock_pwd.call_args[1]
+        # Requested values are applied over the null (unconfigured) current ones
+        assert call_kwargs["lockout_duration"] == 900000
+        assert call_kwargs["min_password_length"] == 14
+        assert call_kwargs["min_character_groups"] == 4
+        assert call_kwargs["min_characters_per_group"] == 1
+        assert call_kwargs["enforce_dictionary_check"] is True
+        assert call_kwargs["enforce_username_check"] is True
+        assert call_kwargs["password_history"] == 24
+        mock_module.exit_json.assert_called_once_with(changed=True)
+
     @patch("plugins.modules.purefa_policy.get_with_context")
     @patch("plugins.modules.purefa_policy.LooseVersion", side_effect=LooseVersion)
     def test_no_change_when_all_params_none(self, mock_lv, mock_get):
@@ -4305,3 +4378,37 @@ class TestUpdateQuotaPolicyBugFixes:
         # Should create a new rule with 'none' notification
         mock_post.assert_called()
         mock_module.exit_json.assert_called_once_with(changed=True)
+
+
+class TestPasswordPolicyVersionGates:
+    """Version gating for password-policy parameters (issue #1030 / PR #1031)"""
+
+    @patch("plugins.modules.purefa_policy.HAS_PURESTORAGE", True)
+    @patch("plugins.modules.purefa_policy.get_array")
+    @patch("plugins.modules.purefa_policy.AnsibleModule")
+    @patch("plugins.modules.purefa_policy.LooseVersion", side_effect=LooseVersion)
+    def test_max_password_age_requires_2_39(self, mock_lv, mock_am, mock_get_array):
+        """max_password_age on a pre-2.39 array fails with a clear version error"""
+        mock_module = Mock()
+        mock_module.params = {
+            "policy": "password",
+            "max_password_age": "90d",
+            "min_password_age": None,
+            "lockout_duration": None,
+            "state": "present",
+            "quota_notifications": None,
+        }
+        mock_module.fail_json.side_effect = SystemExit
+        mock_am.return_value = mock_module
+
+        mock_array = Mock()
+        mock_array.get_rest_version.return_value = "2.38"
+        mock_get_array.return_value = mock_array
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        msgs = [c.kwargs.get("msg", "") for c in mock_module.fail_json.call_args_list]
+        assert any("max_password_age" in m and "2.39" in m for m in msgs)


### PR DESCRIPTION
## Summary

Fixes two password-policy problems in `purefa_policy`, both surfaced by #1030.

### 1. `AttributeError` on null password-policy fields (the reported crash)

Updating a password policy read `pwd_policy.<field>` directly for
`enforce_dictionary_check`, `enforce_username_check`, `lockout_duration`,
`min_character_groups`, `min_characters_per_group` and `min_password_length`.

On newer `py-pure-client` the pydantic models raise `AttributeError` when such a
field is `null` — e.g. `lockout_duration` on a `management` policy that has never
had it set — so the module crashed before it could compare or apply the requested
configuration:

```
File ".../purefa_policy.py", line 2007, in update_policy
    "lockout_duration": pwd_policy.lockout_duration,
AttributeError
```

These fields are now read with `getattr(..., None)` (matching the fields already
handled that way), treating `null` as *not configured*: a `None` differs from any
requested value, so the requested setting is still applied, and
`PolicyPassword.to_dict()` omits `None` fields so nothing spurious is sent.

### 2. `max_password_age` was not version-gated

Diffing the `PolicyPassword` model across REST versions shows `max_password_age`
was **added in REST API 2.39** (2.34 introduced password policies; 2.38 added
`context`). The module allowed it whenever password policies were supported
(2.34), so setting it on a 2.34–2.38 array would send an unsupported field.

It is now gated behind `MAX_PASSWORD_AGE_VERSION = "2.39"`, returning a clear
error on older arrays, with a matching note in the module documentation.

`PASSWORD_VERSION` is left at `2.34` — verified against the SDK as the version
that introduced the password-policy endpoints.

## Tests

- `test_update_password_policy_null_fields` — uses a `spec`-limited mock so direct
  attribute access on the nullable fields raises `AttributeError` (mirroring the
  SDK); fails on the old code, passes with the fix.
- `test_max_password_age_requires_2_39` — asserts the new version gate.

Full `test_purefa_policy.py` suite: **128 passed**; `black` clean.

Fixes #1030
