### PR TITLE
fix(purefa_network): Fix clearing an address always reporting changed

### DIFF
--- a/changelogs/fragments/1043_fix_purefa_network_clear_address.yaml
+++ b/changelogs/fragments/1043_fix_purefa_network_clear_address.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - purefa_network - Fixed removing an address or gateway from an ethernet interface always reporting ``changed``
+  - purefa_network - Fixed ``AttributeError`` when setting an address without a gateway on an interface that has no gateway configured

--- a/plugins/modules/purefa_network.py
+++ b/plugins/modules/purefa_network.py
@@ -178,6 +178,25 @@ from ansible_collections.everpure.flasharray.plugins.module_utils.api_helpers im
     check_response,
 )
 
+# An unconfigured address, netmask or gateway is reported by the array as null,
+# but is cleared by writing 0.0.0.0 (or :: for IPv6). Those describe the same
+# state, so both have to be reduced to a single representation before the
+# current and desired settings can be compared - otherwise clearing an address
+# looks like a change that still needs making on every subsequent run.
+UNSET_IP = (None, "", "0.0.0.0", "::")
+UNSET_NETMASK = (None, "", "0.0.0.0", "0")
+
+
+def _comparable_state(state):
+    """Return a copy of an interface state with cleared IP settings unified"""
+    comparable = dict(state)
+    for setting in ("address", "gateway"):
+        if comparable[setting] in UNSET_IP:
+            comparable[setting] = ""
+    if comparable["netmask"] in UNSET_NETMASK:
+        comparable["netmask"] = ""
+    return comparable
+
 
 def update_fc_interface(module, array, interface):
     """Modify FC Interface settings"""
@@ -380,7 +399,10 @@ def update_interface(module, array):
         ]:
             if module.params["gateway"] not in IPNetwork(module.params["address"]):
                 module.fail_json(msg="Gateway and subnet are not compatible.")
-        if not module.params["gateway"] and interface.eth.gateway not in [
+        # current_state holds the gateway read with a default - reading
+        # interface.eth.gateway directly raises AttributeError on an
+        # interface that has no gateway configured
+        if not module.params["gateway"] and current_state["gateway"] not in [
             None,
             IPNetwork(module.params["address"]),
         ]:
@@ -439,7 +461,7 @@ def update_interface(module, array):
                     module.fail_json(
                         msg="Changing IP protocol requires gateway to change as well."
                     )
-    if new_state != current_state:
+    if _comparable_state(new_state) != _comparable_state(current_state):
         changed = True
         if module.params["servicelist"] and sorted(
             module.params["servicelist"]

--- a/tests/unit/plugins/modules/test_purefa_network.py
+++ b/tests/unit/plugins/modules/test_purefa_network.py
@@ -2950,3 +2950,238 @@ class TestUpdateInterfaceGatewayOnlyBugFixes:
         update_interface(mock_module, mock_array)
 
         mock_module.exit_json.assert_called_once_with(changed=True)
+
+
+class FakeEth:
+    """Stand-in for the SDK's eth model.
+
+    py-pure-client models raise AttributeError for any field the array
+    returned as null rather than returning None. Mock objects do not, which
+    hides code paths that read an unset setting without a getattr default.
+    """
+
+    def __init__(self, **fields):
+        self._fields = fields
+
+    def __getattr__(self, name):
+        value = self._fields.get(name)
+        if value is None:
+            raise AttributeError(name)
+        return value
+
+
+class FakeIPNetwork:
+    """Minimal IPNetwork stand-in - the real netaddr is mocked out globally.
+
+    The global mock returns a 255.255.255.0 netmask for every input, which
+    cannot express the 0.0.0.0/0 used to clear an address.
+    """
+
+    _NETMASKS = {"0": "0.0.0.0", "16": "255.255.0.0", "24": "255.255.255.0"}
+
+    def __init__(self, cidr):
+        self.cidr = str(cidr)
+        self.netmask = self._NETMASKS[self.cidr.split("/", 1)[1]]
+
+    def __contains__(self, item):
+        return True
+
+
+class FakeIPAddress:
+    """Minimal IPAddress stand-in, paired with FakeIPNetwork"""
+
+    _NETMASK_BITS = {"0.0.0.0": 0, "255.255.0.0": 16, "255.255.255.0": 24}
+
+    def __init__(self, address):
+        self.address = str(address)
+
+    def netmask_bits(self):
+        return self._NETMASK_BITS[self.address]
+
+    @property
+    def version(self):
+        return 6 if ":" in self.address else 4
+
+
+def _clear_params(name="ct0.eth4"):
+    """Params for the play in issue #1042 - remove address and gateway"""
+    return {
+        "name": name,
+        "state": "present",
+        "address": "0.0.0.0/0",
+        "gateway": "0.0.0.0",
+        "mtu": None,
+        "servicelist": None,
+        "subinterfaces": None,
+        "subordinates": None,
+        "enabled": True,
+    }
+
+
+def _eth_interface(eth, services=None):
+    interface = Mock()
+    interface.name = "ct0.eth4"
+    interface.enabled = True
+    interface.services = services if services is not None else ["iscsi"]
+    interface.eth = eth
+    return interface
+
+
+class TestUpdateEthInterfaceClearAddress:
+    """Regression tests for issue #1042 - clearing an address reports changed"""
+
+    @patch("plugins.modules.purefa_network.IPAddress", FakeIPAddress)
+    @patch("plugins.modules.purefa_network.IPNetwork", FakeIPNetwork)
+    def test_clear_address_is_idempotent(self):
+        """Re-running the clear play on a cleared interface reports no change"""
+        import pytest
+
+        mock_module = Mock()
+        mock_module.check_mode = False
+        mock_module.exit_json.side_effect = SystemExit(0)
+        mock_module.params = _clear_params()
+        mock_array = Mock()
+        # An interface with no IP settings - the array reports them as null
+        interface = _eth_interface(
+            FakeEth(
+                mtu=1500,
+                subinterfaces=[],
+                address=None,
+                netmask=None,
+                gateway=None,
+            )
+        )
+        mock_array.get_network_interfaces.return_value = Mock(items=[interface])
+
+        with pytest.raises(SystemExit):
+            update_interface(mock_module, mock_array)
+
+        mock_array.patch_network_interfaces.assert_not_called()
+        mock_module.exit_json.assert_called_once_with(changed=False)
+
+    @patch("plugins.modules.purefa_network.IPAddress", FakeIPAddress)
+    @patch("plugins.modules.purefa_network.IPNetwork", FakeIPNetwork)
+    def test_clear_address_is_idempotent_when_array_reports_zeros(self):
+        """A cleared interface reported as 0.0.0.0 also reports no change"""
+        import pytest
+
+        mock_module = Mock()
+        mock_module.check_mode = False
+        mock_module.exit_json.side_effect = SystemExit(0)
+        mock_module.params = _clear_params()
+        mock_array = Mock()
+        interface = _eth_interface(
+            FakeEth(
+                mtu=1500,
+                subinterfaces=[],
+                address="0.0.0.0",
+                netmask="",
+                gateway="0.0.0.0",
+            )
+        )
+        mock_array.get_network_interfaces.return_value = Mock(items=[interface])
+
+        with pytest.raises(SystemExit):
+            update_interface(mock_module, mock_array)
+
+        mock_array.patch_network_interfaces.assert_not_called()
+        mock_module.exit_json.assert_called_once_with(changed=False)
+
+    @patch("plugins.modules.purefa_network.check_response")
+    @patch("plugins.modules.purefa_network.IPAddress", FakeIPAddress)
+    @patch("plugins.modules.purefa_network.IPNetwork", FakeIPNetwork)
+    def test_clear_address_on_configured_interface_changes(self, mock_check_response):
+        """The first run against a configured interface still clears it"""
+        import pytest
+
+        mock_module = Mock()
+        mock_module.check_mode = False
+        mock_module.exit_json.side_effect = SystemExit(0)
+        mock_module.params = _clear_params()
+        mock_array = Mock()
+        interface = _eth_interface(
+            FakeEth(
+                mtu=1500,
+                subinterfaces=[],
+                address="10.21.200.18",
+                netmask="255.255.255.0",
+                gateway="10.21.200.1",
+            )
+        )
+        mock_array.get_network_interfaces.return_value = Mock(items=[interface])
+        mock_array.patch_network_interfaces.return_value = Mock(status_code=200)
+
+        with pytest.raises(SystemExit):
+            update_interface(mock_module, mock_array)
+
+        mock_array.patch_network_interfaces.assert_called()
+        mock_module.exit_json.assert_called_once_with(changed=True)
+
+    @patch("plugins.modules.purefa_network.check_response")
+    @patch("plugins.modules.purefa_network.IPAddress", FakeIPAddress)
+    @patch("plugins.modules.purefa_network.IPNetwork", FakeIPNetwork)
+    def test_set_address_on_cleared_interface_changes(self, mock_check_response):
+        """Setting an address on a cleared interface is still a change"""
+        import pytest
+
+        mock_module = Mock()
+        mock_module.check_mode = False
+        mock_module.exit_json.side_effect = SystemExit(0)
+        mock_module.params = _clear_params()
+        mock_module.params["address"] = "10.21.200.18/24"
+        mock_module.params["gateway"] = "10.21.200.1"
+        mock_array = Mock()
+        interface = _eth_interface(
+            FakeEth(
+                mtu=1500,
+                subinterfaces=[],
+                address=None,
+                netmask=None,
+                gateway=None,
+            )
+        )
+        mock_array.get_network_interfaces.return_value = Mock(items=[interface])
+        mock_array.patch_network_interfaces.return_value = Mock(status_code=200)
+
+        with pytest.raises(SystemExit):
+            update_interface(mock_module, mock_array)
+
+        mock_array.patch_network_interfaces.assert_called()
+        mock_module.exit_json.assert_called_once_with(changed=True)
+
+    @patch("plugins.modules.purefa_network.check_response")
+    @patch("plugins.modules.purefa_network.IPAddress", FakeIPAddress)
+    @patch("plugins.modules.purefa_network.IPNetwork", FakeIPNetwork)
+    def test_set_address_without_gateway_on_interface_with_no_gateway(
+        self, mock_check_response
+    ):
+        """Setting an address with no gateway must not raise AttributeError
+
+        The gateway compatibility check read interface.eth.gateway directly,
+        which raises AttributeError when the interface has no gateway.
+        """
+        import pytest
+
+        mock_module = Mock()
+        mock_module.check_mode = False
+        mock_module.exit_json.side_effect = SystemExit(0)
+        mock_module.params = _clear_params()
+        mock_module.params["address"] = "10.21.200.18/24"
+        mock_module.params["gateway"] = None
+        mock_array = Mock()
+        interface = _eth_interface(
+            FakeEth(
+                mtu=1500,
+                subinterfaces=[],
+                address=None,
+                netmask=None,
+                gateway=None,
+            )
+        )
+        mock_array.get_network_interfaces.return_value = Mock(items=[interface])
+        mock_array.patch_network_interfaces.return_value = Mock(status_code=200)
+
+        with pytest.raises(SystemExit):
+            update_interface(mock_module, mock_array)
+
+        mock_module.exit_json.assert_called_once_with(changed=True)


### PR DESCRIPTION
##### SUMMARY

Fixes #1042

`update_interface()` reads the current IP settings from the array, where an unconfigured address, netmask or gateway comes back as null, but builds the desired settings using the `0.0.0.0` and `""` values that *clear* them. Those two describe the same state, so once an interface had been cleared the comparison could never match:

```
current: {'address': None,      'netmask': None, 'gateway': None}
new:     {'address': '0.0.0.0', 'netmask': '',   'gateway': ''}
```

Every subsequent run reported `changed` and re-PATCHed the interface.

Both sides of that comparison are now reduced to a single representation of "not configured" before being compared, via `_comparable_state()`. Normalising the comparison rather than the settings themselves is deliberate: the desired settings used to build the PATCH payload are untouched, so what actually gets written to the array is unchanged by this PR. It also means the fix holds whichever way the array represents a cleared interface - null or `0.0.0.0` - and there is a test for each.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_network

##### ADDITIONAL INFORMATION

**Second bug fixed alongside it.** The gateway compatibility check read `interface.eth.gateway` directly:

```python
if not module.params["gateway"] and interface.eth.gateway not in [
```

The py-pure-client models raise `AttributeError` for any field the array returned as null, which is why every other read of these settings goes through `getattr(interface.eth, ..., None)`. Setting an address without a gateway, on an interface that has no gateway configured, therefore crashed the module with `AttributeError: gateway`. It now reads from `current_state`, which already holds that value with a default. Caught by one of the new tests rather than by inspection.

**Separate concern, not addressed here.** That same check compares a gateway string against an `IPNetwork` object:

```python
if not module.params["gateway"] and current_state["gateway"] not in [
    None,
    IPNetwork(module.params["address"]),
]:
```

`"10.1.1.1" == IPNetwork("10.1.1.0/24")` is always `False`, so the condition reduces to "a gateway is configured" and the module fails with "Gateway and subnet are not compatible" whenever you change an address without also passing a gateway - even when the new subnet does contain the existing gateway. It looks like it was meant to be `IPAddress(gateway) not in IPNetwork(address)`. I have left it alone because correcting it loosens a validation rule and is a behaviour change worth deciding on separately, but it is worth a look.

**On the tests.** The module's existing tests mock `netaddr` globally, with `IPNetwork(...)` returning a fixed `255.255.255.0` netmask for every input - which cannot express the `0.0.0.0/0` used to clear an address. The new tests therefore patch in small `FakeIPNetwork`/`FakeIPAddress` stand-ins with real netmask semantics for the handful of prefixes they use, rather than adding a hard dependency on netaddr being installed in the unit-test environment. They also use a `FakeEth` that raises `AttributeError` for nulls the way the SDK models do; a plain `Mock` returns `None` instead, which is what hid the `AttributeError` above.

Verified the new tests actually bite, by reverting the module fix and re-running them:

```paste below
FAILED tests/unit/plugins/modules/test_purefa_network.py::TestUpdateEthInterfaceClearAddress::test_clear_address_is_idempotent
FAILED tests/unit/plugins/modules/test_purefa_network.py::TestUpdateEthInterfaceClearAddress::test_clear_address_is_idempotent_when_array_reports_zeros
FAILED tests/unit/plugins/modules/test_purefa_network.py::TestUpdateEthInterfaceClearAddress::test_set_address_without_gateway_on_interface_with_no_gateway
3 failed, 2 passed
```

The two that pass both before and after are the guards against over-correcting: clearing a configured interface, and setting an address on a cleared one, must both still report `changed`.

Full suite after the fix: `pytest tests/unit` - 2210 passed. `black --check` clean on both changed files.

Changelog fragment included: `changelogs/fragments/1043_fix_purefa_network_clear_address.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
