### PR TITLE
feat(purefa_timezone): Add module to manage the array system time zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ All modules are idempotent with the exception of modules that change or set pass
 - purefa_tgroup - manage topology groups and their memberships on the FlashArray
 - purefa_token - manage FlashArray user API tokens
 - purefa_timeout - manage the GUI idle timeout on the FlashArray
+- purefa_timezone - manage the system time zone on the FlashArray
 - purefa_user - manage local user accounts on the FlashArray
 - purefa_vg - manage volume groups on the FlashArray
 - purefa_vlan - manage VLAN interfaces on the FlashArray

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -63,6 +63,7 @@ action_groups:
    - purefa_syslog_settings
    - purefa_tgroup
    - purefa_timeout
+   - purefa_timezone
    - purefa_token
    - purefa_user
    - purefa_vg

--- a/plugins/modules/purefa_timezone.py
+++ b/plugins/modules/purefa_timezone.py
@@ -1,0 +1,162 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2026, Simon Dodsley (simon@everpuredata.com)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+DOCUMENTATION = r"""
+---
+module: purefa_timezone
+version_added: '1.45.0'
+short_description: Configure Everpure FlashArray system time zone
+description:
+- Configure the system time zone for Everpure FlashArrays.
+- Ideal for Day 0 initial configuration.
+- The current time zone of an array is reported by the C(config) subset
+  of M(everpure.flasharray.purefa_info).
+author:
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@everpuredata.com>
+options:
+  state:
+    description:
+    - Set the array time zone
+    type: str
+    default: present
+    choices: [ present ]
+  timezone:
+    description:
+    - Name of the time zone to set, as used by the IANA time zone database,
+      eg. C(America/New_York) or C(Europe/London).
+    - Validated against the time zone database of the C(pytz) module
+      installed on the Ansible control node.
+    type: str
+    required: true
+  context:
+    description:
+    - Name of fleet member on which to perform the operation.
+    - This requires the array receiving the request is a member of a fleet
+      and the context name to be a member of the same fleet.
+    type: str
+    default: ""
+extends_documentation_fragment:
+- everpure.flasharray.everpure.fa
+notes:
+- This module requires the C(pytz) Python library.
+- Requires Purity//FA REST API 2.26 or higher.
+"""
+
+EXAMPLES = r"""
+- name: Set array time zone
+  everpure.flasharray.purefa_timezone:
+    timezone: America/New_York
+    fa_url: 10.10.10.2
+    api_token: e31060a7-21fc-e277-6240-25983c6c4592
+
+- name: Set the time zone of a fleet member
+  everpure.flasharray.purefa_timezone:
+    timezone: Europe/London
+    context: remote-array
+    fa_url: 10.10.10.2
+    api_token: e31060a7-21fc-e277-6240-25983c6c4592
+"""
+
+RETURN = r"""
+"""
+
+HAS_PYTZ = True
+try:
+    import pytz
+except ImportError:
+    HAS_PYTZ = False
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.everpure.flasharray.plugins.module_utils.purefa import (
+    get_array,
+    purefa_argument_spec,
+)
+from ansible_collections.everpure.flasharray.plugins.module_utils.api_helpers import (
+    check_api_version,
+    check_response,
+    get_with_context,
+)
+
+CONTEXT_VERSION = "2.38"
+TIMEZONE_VERSION = "2.26"
+
+
+def update_timezone(module, array):
+    """Change the array time zone"""
+    changed = True
+    if not module.check_mode:
+        # The SDK marks time_zone as a read-only field of the Arrays model, so
+        # it is dropped when a request body is built from Arrays(time_zone=...).
+        # Pass the body as a dict so that the field reaches the array.
+        res = get_with_context(
+            array,
+            "patch_arrays",
+            CONTEXT_VERSION,
+            module,
+            array={"time_zone": module.params["timezone"]},
+        )
+        check_response(
+            res,
+            module,
+            "Failed to set array time zone to {0}".format(module.params["timezone"]),
+        )
+        # The array echoes back the object it has just modified. As time_zone
+        # is flagged read-only by the API spec, confirm the array really did
+        # take the new value instead of quietly ignoring the field.
+        applied = getattr(next(iter(list(res.items)), None), "time_zone", None)
+        if applied is not None and applied != module.params["timezone"]:
+            module.fail_json(
+                msg="Array did not apply the requested time zone {0}. "
+                "Time zone is {1}".format(module.params["timezone"], applied)
+            )
+
+    module.exit_json(changed=changed)
+
+
+def main():
+    argument_spec = purefa_argument_spec()
+    argument_spec.update(
+        dict(
+            timezone=dict(type="str", required=True),
+            state=dict(type="str", default="present", choices=["present"]),
+            context=dict(type="str", default=""),
+        )
+    )
+
+    module = AnsibleModule(argument_spec, supports_check_mode=True)
+
+    if not HAS_PYTZ:
+        module.fail_json(msg="pytz is required for this module")
+
+    if module.params["timezone"] not in pytz.all_timezones_set:
+        module.fail_json(
+            msg="Timezone {0} is not valid".format(module.params["timezone"])
+        )
+
+    array = get_array(module)
+    check_api_version(array, TIMEZONE_VERSION, module, "Array time zone management")
+
+    res = get_with_context(array, "get_arrays", CONTEXT_VERSION, module)
+    check_response(res, module, "Failed to get current array time zone")
+    current_timezone = getattr(list(res.items)[0], "time_zone", None)
+    if current_timezone != module.params["timezone"]:
+        update_timezone(module, array)
+
+    module.exit_json(changed=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -113,6 +113,7 @@ plugins/modules/purefa_syslog.py import-2.7
 plugins/modules/purefa_syslog_settings.py import-2.7
 plugins/modules/purefa_tgroup.py import-2.7
 plugins/modules/purefa_timeout.py import-2.7
+plugins/modules/purefa_timezone.py import-2.7
 plugins/modules/purefa_token.py import-2.7
 plugins/modules/purefa_user.py import-2.7
 plugins/modules/purefa_vg.py import-2.7

--- a/tests/unit/plugins/modules/test_purefa_timezone.py
+++ b/tests/unit/plugins/modules/test_purefa_timezone.py
@@ -1,0 +1,311 @@
+# Copyright: (c) 2026, Everpure Ansible Team <pure-ansible-team@everpuredata.com>
+# GNU General Public License v3.0+ (see COPYING.GPLv3 or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for purefa_timezone module."""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import sys
+from unittest.mock import Mock, patch, MagicMock
+
+# Mock external dependencies before importing module
+sys.modules["grp"] = MagicMock()
+sys.modules["pwd"] = MagicMock()
+sys.modules["fcntl"] = MagicMock()
+sys.modules["ansible"] = MagicMock()
+sys.modules["ansible.module_utils"] = MagicMock()
+sys.modules["ansible.module_utils.basic"] = MagicMock()
+sys.modules["pypureclient"] = MagicMock()
+sys.modules["pypureclient.flasharray"] = MagicMock()
+sys.modules["ansible_collections"] = MagicMock()
+sys.modules["ansible_collections.everpure"] = MagicMock()
+sys.modules["ansible_collections.everpure.flasharray"] = MagicMock()
+sys.modules["ansible_collections.everpure.flasharray.plugins"] = MagicMock()
+sys.modules["ansible_collections.everpure.flasharray.plugins.module_utils"] = (
+    MagicMock()
+)
+sys.modules["ansible_collections.everpure.flasharray.plugins.module_utils.purefa"] = (
+    MagicMock()
+)
+sys.modules[
+    "ansible_collections.everpure.flasharray.plugins.module_utils.api_helpers"
+] = MagicMock()
+
+# pytz may not be installed in the test environment, and another test module
+# may already have replaced it, so stub it out here and patch the module's own
+# reference in each test that needs a known set of zone names.
+if "pytz" not in sys.modules:
+    sys.modules["pytz"] = MagicMock()
+
+from plugins.modules.purefa_timezone import main, update_timezone
+
+
+def _pytz_stub():
+    """Return a pytz stub holding a known set of time zone names"""
+    stub = Mock()
+    stub.all_timezones_set = {"UTC", "America/New_York", "Europe/London"}
+    return stub
+
+
+def _patch_response(timezone):
+    """Return a mock patch_arrays response echoing back the given time zone"""
+    updated = Mock()
+    updated.time_zone = timezone
+    response = Mock()
+    response.status_code = 200
+    response.items = [updated]
+    return response
+
+
+class TestUpdateTimezone:
+    """Test cases for update_timezone function"""
+
+    @patch("plugins.modules.purefa_timezone.check_response")
+    @patch("plugins.modules.purefa_timezone.get_with_context")
+    def test_update_timezone_success(self, mock_get_with_context, mock_check_response):
+        """Test successful time zone update"""
+        mock_module = Mock()
+        mock_module.check_mode = False
+        mock_module.params = {"timezone": "America/New_York"}
+
+        mock_array = Mock()
+        mock_get_with_context.return_value = _patch_response("America/New_York")
+
+        update_timezone(mock_module, mock_array)
+
+        mock_get_with_context.assert_called_once()
+        mock_check_response.assert_called_once()
+        mock_module.fail_json.assert_not_called()
+        mock_module.exit_json.assert_called_once_with(changed=True)
+
+    @patch("plugins.modules.purefa_timezone.check_response")
+    @patch("plugins.modules.purefa_timezone.get_with_context")
+    def test_update_timezone_sends_dict_body(
+        self, mock_get_with_context, mock_check_response
+    ):
+        """Test the patch body carries time_zone
+
+        time_zone is a read-only field of the SDK Arrays model, so it is only
+        sent if the body is passed as a dict. Building the body from
+        Arrays(time_zone=...) would silently patch nothing.
+        """
+        mock_module = Mock()
+        mock_module.check_mode = False
+        mock_module.params = {"timezone": "Europe/London"}
+
+        mock_array = Mock()
+        mock_get_with_context.return_value = _patch_response("Europe/London")
+
+        update_timezone(mock_module, mock_array)
+
+        call_args = mock_get_with_context.call_args
+        assert call_args[0][1] == "patch_arrays"
+        assert call_args[1]["array"] == {"time_zone": "Europe/London"}
+
+    @patch("plugins.modules.purefa_timezone.check_response")
+    @patch("plugins.modules.purefa_timezone.get_with_context")
+    def test_update_timezone_not_applied(
+        self, mock_get_with_context, mock_check_response
+    ):
+        """Test failure when the array does not take the new time zone"""
+        mock_module = Mock()
+        mock_module.check_mode = False
+        mock_module.params = {"timezone": "Europe/London"}
+        mock_module.fail_json.side_effect = SystemExit("fail_json called")
+
+        mock_array = Mock()
+        # Array reported success but kept its old time zone
+        mock_get_with_context.return_value = _patch_response("UTC")
+
+        try:
+            update_timezone(mock_module, mock_array)
+        except SystemExit:
+            pass
+
+        mock_module.fail_json.assert_called_once()
+        call_args = mock_module.fail_json.call_args[1]
+        assert "did not apply the requested time zone" in call_args["msg"]
+        mock_module.exit_json.assert_not_called()
+
+    @patch("plugins.modules.purefa_timezone.check_response")
+    @patch("plugins.modules.purefa_timezone.get_with_context")
+    def test_update_timezone_no_echo(self, mock_get_with_context, mock_check_response):
+        """Test success when the response does not report a time zone"""
+        mock_module = Mock()
+        mock_module.check_mode = False
+        mock_module.params = {"timezone": "Europe/London"}
+
+        mock_array = Mock()
+        mock_get_with_context.return_value = _patch_response(None)
+
+        update_timezone(mock_module, mock_array)
+
+        mock_module.fail_json.assert_not_called()
+        mock_module.exit_json.assert_called_once_with(changed=True)
+
+    @patch("plugins.modules.purefa_timezone.check_response")
+    @patch("plugins.modules.purefa_timezone.get_with_context")
+    def test_update_timezone_check_mode(
+        self, mock_get_with_context, mock_check_response
+    ):
+        """Test time zone update in check mode"""
+        mock_module = Mock()
+        mock_module.check_mode = True
+        mock_module.params = {"timezone": "America/New_York"}
+
+        mock_array = Mock()
+
+        update_timezone(mock_module, mock_array)
+
+        # Should not call API in check mode
+        mock_get_with_context.assert_not_called()
+        mock_check_response.assert_not_called()
+        mock_module.exit_json.assert_called_once_with(changed=True)
+
+
+class TestMain:
+    """Test cases for main function"""
+
+    @patch("plugins.modules.purefa_timezone.get_array")
+    @patch("plugins.modules.purefa_timezone.AnsibleModule")
+    @patch("plugins.modules.purefa_timezone.HAS_PYTZ", False)
+    def test_main_missing_pytz(self, mock_ansible_module, mock_get_array):
+        """Test main when pytz is missing"""
+        mock_module = Mock()
+        mock_module.params = {
+            "timezone": "America/New_York",
+            "state": "present",
+            "context": "",
+        }
+        mock_module.fail_json.side_effect = SystemExit("fail_json called")
+        mock_ansible_module.return_value = mock_module
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        mock_module.fail_json.assert_called_once()
+        call_args = mock_module.fail_json.call_args[1]
+        assert "pytz is required" in call_args["msg"]
+        mock_get_array.assert_not_called()
+
+    @patch("plugins.modules.purefa_timezone.pytz", new_callable=_pytz_stub)
+    @patch("plugins.modules.purefa_timezone.get_array")
+    @patch("plugins.modules.purefa_timezone.AnsibleModule")
+    @patch("plugins.modules.purefa_timezone.HAS_PYTZ", True)
+    def test_main_invalid_timezone(
+        self, mock_ansible_module, mock_get_array, mock_pytz
+    ):
+        """Test main with a time zone that is not in the tz database"""
+        mock_module = Mock()
+        mock_module.params = {
+            "timezone": "Mars/Olympus_Mons",
+            "state": "present",
+            "context": "",
+        }
+        mock_module.fail_json.side_effect = SystemExit("fail_json called")
+        mock_ansible_module.return_value = mock_module
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        mock_module.fail_json.assert_called_once()
+        call_args = mock_module.fail_json.call_args[1]
+        assert "is not valid" in call_args["msg"]
+        # The array should not be contacted with an invalid time zone
+        mock_get_array.assert_not_called()
+
+    @patch("plugins.modules.purefa_timezone.check_response")
+    @patch("plugins.modules.purefa_timezone.get_with_context")
+    @patch("plugins.modules.purefa_timezone.check_api_version")
+    @patch("plugins.modules.purefa_timezone.pytz", new_callable=_pytz_stub)
+    @patch("plugins.modules.purefa_timezone.get_array")
+    @patch("plugins.modules.purefa_timezone.AnsibleModule")
+    @patch("plugins.modules.purefa_timezone.HAS_PYTZ", True)
+    def test_main_timezone_unchanged(
+        self,
+        mock_ansible_module,
+        mock_get_array,
+        mock_pytz,
+        mock_check_api_version,
+        mock_get_with_context,
+        mock_check_response,
+    ):
+        """Test main when the requested time zone is already set"""
+        mock_module = Mock()
+        mock_module.params = {
+            "timezone": "Europe/London",
+            "state": "present",
+            "context": "",
+        }
+        mock_ansible_module.return_value = mock_module
+
+        mock_array = Mock()
+        mock_get_array.return_value = mock_array
+
+        mock_current = Mock()
+        mock_current.time_zone = "Europe/London"  # Same as requested
+        mock_response = Mock()
+        mock_response.items = [mock_current]
+        mock_get_with_context.return_value = mock_response
+
+        main()
+
+        mock_check_api_version.assert_called_once()
+        mock_module.exit_json.assert_called_once_with(changed=False)
+
+    @patch("plugins.modules.purefa_timezone.check_response")
+    @patch("plugins.modules.purefa_timezone.get_with_context")
+    @patch("plugins.modules.purefa_timezone.check_api_version")
+    @patch("plugins.modules.purefa_timezone.pytz", new_callable=_pytz_stub)
+    @patch("plugins.modules.purefa_timezone.get_array")
+    @patch("plugins.modules.purefa_timezone.AnsibleModule")
+    @patch("plugins.modules.purefa_timezone.HAS_PYTZ", True)
+    def test_main_timezone_changed(
+        self,
+        mock_ansible_module,
+        mock_get_array,
+        mock_pytz,
+        mock_check_api_version,
+        mock_get_with_context,
+        mock_check_response,
+    ):
+        """Test main patches the array when the time zone differs"""
+        mock_module = Mock()
+        mock_module.check_mode = False
+        mock_module.params = {
+            "timezone": "America/New_York",
+            "state": "present",
+            "context": "",
+        }
+        # exit_json ends the module run, as it does under Ansible
+        mock_module.exit_json.side_effect = SystemExit("exit_json called")
+        mock_ansible_module.return_value = mock_module
+
+        mock_array = Mock()
+        mock_get_array.return_value = mock_array
+
+        mock_current = Mock()
+        mock_current.time_zone = "UTC"
+        mock_get_response = Mock()
+        mock_get_response.items = [mock_current]
+        mock_get_with_context.side_effect = [
+            mock_get_response,
+            _patch_response("America/New_York"),
+        ]
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        assert mock_get_with_context.call_count == 2
+        patch_call = mock_get_with_context.call_args_list[1]
+        assert patch_call[0][1] == "patch_arrays"
+        assert patch_call[1]["array"] == {"time_zone": "America/New_York"}
+        mock_module.exit_json.assert_called_once_with(changed=True)


### PR DESCRIPTION
##### SUMMARY
The collection covers the other day-0 baseline settings - DNS, NTP, directory services, SMTP, alerts, banner, GUI timeout and eradication - but the system time zone had to be reached around the collection for, typically with ansible.builtin.uri against the REST API directly.

The new module sets the array time zone, taking an IANA time zone name. The value is validated against the pytz time zone database, which the collection already requires, before the array is contacted, and the module requires REST API 2.26 or higher, which is where time_zone appears on the arrays endpoint. Fleet members are supported through the usual context parameter.

The SDK flags time_zone as a read-only field of the Arrays model, and request bodies are serialised with as_request_dict(), which drops every read-only field. A body built as Arrays(time_zone=...) therefore serialises to {} and patches nothing at all, while the module would still report changed. The body is instead passed as a dict, which the serialiser sends verbatim, and because the field is read-only by the spec, the time zone the array echoes back in its response is compared against the requested one so that a quietly ignored field is reported as a failure rather than as success.

The current time zone of an array is already reported by the config subset of purefa_info.

Closes #1044

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
purefa_timezone.py