### PR TITLE
fix(purefa_fs): Make rename idempotent

### DIFF
--- a/changelogs/fragments/1050_purefa_fs_rename_idempotency.yaml
+++ b/changelogs/fragments/1050_purefa_fs_rename_idempotency.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - purefa_fs - Fix rename so that re-running a rename task reports no change,
+    instead of recreating the file system under its original name.

--- a/plugins/modules/purefa_fs.py
+++ b/plugins/modules/purefa_fs.py
@@ -45,6 +45,8 @@ options:
     - Value to rename the specified file system to
     - Rename only applies to the container the current filesystem is in.
     - There is no requirement to specify the pod name as this is implied.
+    - Re-running a rename task reports no change, as long as the file system
+      is already known by the new name.
     type: str
   move:
     description:
@@ -188,14 +190,45 @@ def eradicate_fs(module, array):
     module.exit_json(changed=changed)
 
 
+def rename_target(module):
+    """Return the fully qualified name a rename would give the file system"""
+    if "::" in module.params["name"]:
+        pod_name = module.params["name"].split("::")[0]
+        return pod_name + "::" + module.params["rename"]
+    return module.params["rename"]
+
+
+def check_renamed_fs(module, array):
+    """Report on a rename whose source file system has already gone
+
+    A completed rename leaves nothing under the old name, so a second run of
+    the same task must not create the source again - that would leave the
+    array holding both the renamed file system and a fresh empty one.
+    """
+    target_name = rename_target(module)
+    res = get_with_context(
+        array,
+        "get_file_systems",
+        CONTEXT_VERSION,
+        module,
+        names=[target_name],
+    )
+    if res.status_code != 200:
+        module.fail_json(
+            msg="File system {0} not found to rename".format(module.params["name"])
+        )
+    if list(res.items)[0].destroyed:
+        module.fail_json(
+            msg="File system {0} exists, but in destroyed state".format(target_name)
+        )
+    module.exit_json(changed=False)
+
+
 def rename_fs(module, array):
     """Rename a file system"""
     changed = False
     target = None
-    target_name = module.params["rename"]
-    if "::" in module.params["name"]:
-        pod_name = module.params["name"].split("::")[0]
-        target_name = pod_name + "::" + module.params["rename"]
+    target_name = rename_target(module)
     res = get_with_context(
         array,
         "get_file_systems",
@@ -401,8 +434,15 @@ def main():
         filesystem = list(res.items)[0]
         exists = True
 
-    if state == "present" and not exists and not module.params["move"]:
+    if (
+        state == "present"
+        and not exists
+        and not module.params["move"]
+        and not module.params["rename"]
+    ):
         create_fs(module, array)
+    elif state == "present" and not exists and module.params["rename"]:
+        check_renamed_fs(module, array)
     elif (
         state == "present"
         and exists

--- a/tests/unit/plugins/modules/test_purefa_fs.py
+++ b/tests/unit/plugins/modules/test_purefa_fs.py
@@ -47,6 +47,8 @@ from plugins.modules.purefa_fs import (
     recover_fs,
     eradicate_fs,
     rename_fs,
+    rename_target,
+    check_renamed_fs,
     create_fs,
 )
 
@@ -1232,3 +1234,227 @@ class TestMain:
         purefa_fs_module.main()
 
         mock_module.exit_json.assert_called_once_with(changed=False)
+
+
+class TestRenameTarget:
+    """Test cases for rename_target function"""
+
+    def test_rename_target_local(self):
+        """Test rename_target returns the bare name outside a pod"""
+        mock_module = Mock()
+        mock_module.params = {"name": "old-fs", "rename": "new-fs"}
+
+        assert rename_target(mock_module) == "new-fs"
+
+    def test_rename_target_in_pod(self):
+        """Test rename_target keeps the pod prefix of the source"""
+        mock_module = Mock()
+        mock_module.params = {"name": "mypod::old-fs", "rename": "new-fs"}
+
+        assert rename_target(mock_module) == "mypod::new-fs"
+
+
+class TestCheckRenamedFs:
+    """Test cases for check_renamed_fs function
+
+    This is the second run of a rename task, when the source file system has
+    already gone.
+    """
+
+    @patch("plugins.modules.purefa_fs.get_with_context")
+    def test_check_renamed_fs_already_renamed(self, mock_get_with_context):
+        """Test check_renamed_fs reports no change once the target is there"""
+        mock_module = Mock()
+        mock_module.params = {"name": "old-fs", "rename": "new-fs", "context": ""}
+        mock_array = Mock()
+        mock_target = Mock()
+        mock_target.destroyed = False
+        mock_get_with_context.return_value = Mock(status_code=200, items=[mock_target])
+
+        check_renamed_fs(mock_module, mock_array)
+
+        mock_module.exit_json.assert_called_once_with(changed=False)
+        mock_module.fail_json.assert_not_called()
+
+    @patch("plugins.modules.purefa_fs.get_with_context")
+    def test_check_renamed_fs_in_pod_already_renamed(self, mock_get_with_context):
+        """Test check_renamed_fs looks for the pod qualified target"""
+        mock_module = Mock()
+        mock_module.params = {
+            "name": "mypod::old-fs",
+            "rename": "new-fs",
+            "context": "",
+        }
+        mock_array = Mock()
+        mock_target = Mock()
+        mock_target.destroyed = False
+        mock_get_with_context.return_value = Mock(status_code=200, items=[mock_target])
+
+        check_renamed_fs(mock_module, mock_array)
+
+        assert mock_get_with_context.call_args[1]["names"] == ["mypod::new-fs"]
+        mock_module.exit_json.assert_called_once_with(changed=False)
+
+    @patch("plugins.modules.purefa_fs.get_with_context")
+    def test_check_renamed_fs_neither_exists_fails(self, mock_get_with_context):
+        """Test check_renamed_fs fails rather than creating the source"""
+        import pytest
+
+        mock_module = Mock()
+        mock_module.params = {"name": "old-fs", "rename": "new-fs", "context": ""}
+        mock_module.fail_json.side_effect = SystemExit(1)
+        mock_array = Mock()
+        mock_get_with_context.return_value = Mock(status_code=404)
+
+        with pytest.raises(SystemExit):
+            check_renamed_fs(mock_module, mock_array)
+
+        assert "not found to rename" in mock_module.fail_json.call_args[1]["msg"]
+        mock_module.exit_json.assert_not_called()
+
+    @patch("plugins.modules.purefa_fs.get_with_context")
+    def test_check_renamed_fs_target_destroyed_fails(self, mock_get_with_context):
+        """Test check_renamed_fs fails when the target is in the trash"""
+        import pytest
+
+        mock_module = Mock()
+        mock_module.params = {"name": "old-fs", "rename": "new-fs", "context": ""}
+        mock_module.fail_json.side_effect = SystemExit(1)
+        mock_array = Mock()
+        mock_target = Mock()
+        mock_target.destroyed = True
+        mock_get_with_context.return_value = Mock(status_code=200, items=[mock_target])
+
+        with pytest.raises(SystemExit):
+            check_renamed_fs(mock_module, mock_array)
+
+        assert "destroyed state" in mock_module.fail_json.call_args[1]["msg"]
+        mock_module.exit_json.assert_not_called()
+
+
+class TestMainRenameIdempotency:
+    """Test that a rename task run twice changes once and then reports no change"""
+
+    @staticmethod
+    def _module(mock_ansible_module):
+        mock_module = Mock()
+        mock_module.params = {
+            "name": "old-fs",
+            "state": "present",
+            "move": None,
+            "rename": "new-fs",
+            "eradicate": False,
+            "context": "",
+        }
+        mock_module.fail_json.side_effect = SystemExit(1)
+        mock_ansible_module.return_value = mock_module
+        return mock_module
+
+    @patch("plugins.modules.purefa_fs.LooseVersion")
+    @patch("plugins.modules.purefa_fs.check_renamed_fs")
+    @patch("plugins.modules.purefa_fs.create_fs")
+    @patch("plugins.modules.purefa_fs.rename_fs")
+    @patch("plugins.modules.purefa_fs.get_with_context")
+    @patch("plugins.modules.purefa_fs.get_array")
+    @patch("plugins.modules.purefa_fs.AnsibleModule")
+    def test_main_rename_first_run_renames(
+        self,
+        mock_ansible_module,
+        mock_get_array,
+        mock_get_with_context,
+        mock_rename_fs,
+        mock_create_fs,
+        mock_check_renamed_fs,
+        mock_loose_version,
+    ):
+        """First run: the source is there, so the rename happens"""
+        import plugins.modules.purefa_fs as purefa_fs_module
+
+        mock_module = self._module(mock_ansible_module)
+        mock_array = Mock()
+        mock_array.get_rest_version.return_value = "2.33"
+        mock_get_array.return_value = mock_array
+        mock_loose_version.side_effect = lambda v: Mock(
+            __gt__=lambda self, other: False
+        )
+
+        mock_fs = Mock()
+        mock_fs.destroyed = False
+        mock_get_with_context.return_value = Mock(status_code=200, items=[mock_fs])
+
+        purefa_fs_module.main()
+
+        mock_rename_fs.assert_called_once_with(mock_module, mock_array)
+        mock_create_fs.assert_not_called()
+        mock_check_renamed_fs.assert_not_called()
+
+    @patch("plugins.modules.purefa_fs.LooseVersion")
+    @patch("plugins.modules.purefa_fs.check_renamed_fs")
+    @patch("plugins.modules.purefa_fs.create_fs")
+    @patch("plugins.modules.purefa_fs.rename_fs")
+    @patch("plugins.modules.purefa_fs.get_with_context")
+    @patch("plugins.modules.purefa_fs.get_array")
+    @patch("plugins.modules.purefa_fs.AnsibleModule")
+    def test_main_rename_second_run_does_not_create(
+        self,
+        mock_ansible_module,
+        mock_get_array,
+        mock_get_with_context,
+        mock_rename_fs,
+        mock_create_fs,
+        mock_check_renamed_fs,
+        mock_loose_version,
+    ):
+        """Second run: the source has gone, and must not be created again"""
+        import plugins.modules.purefa_fs as purefa_fs_module
+
+        mock_module = self._module(mock_ansible_module)
+        mock_array = Mock()
+        mock_array.get_rest_version.return_value = "2.33"
+        mock_get_array.return_value = mock_array
+        mock_loose_version.side_effect = lambda v: Mock(
+            __gt__=lambda self, other: False
+        )
+
+        # Nothing under the old name any more
+        mock_get_with_context.return_value = Mock(status_code=404)
+
+        purefa_fs_module.main()
+
+        mock_check_renamed_fs.assert_called_once_with(mock_module, mock_array)
+        mock_create_fs.assert_not_called()
+        mock_rename_fs.assert_not_called()
+
+    @patch("plugins.modules.purefa_fs.LooseVersion")
+    @patch("plugins.modules.purefa_fs.check_renamed_fs")
+    @patch("plugins.modules.purefa_fs.create_fs")
+    @patch("plugins.modules.purefa_fs.get_with_context")
+    @patch("plugins.modules.purefa_fs.get_array")
+    @patch("plugins.modules.purefa_fs.AnsibleModule")
+    def test_main_creates_when_no_rename_requested(
+        self,
+        mock_ansible_module,
+        mock_get_array,
+        mock_get_with_context,
+        mock_create_fs,
+        mock_check_renamed_fs,
+        mock_loose_version,
+    ):
+        """A missing file system with no rename asked for is still created"""
+        import plugins.modules.purefa_fs as purefa_fs_module
+
+        mock_module = self._module(mock_ansible_module)
+        mock_module.params["rename"] = None
+        mock_array = Mock()
+        mock_array.get_rest_version.return_value = "2.33"
+        mock_get_array.return_value = mock_array
+        mock_loose_version.side_effect = lambda v: Mock(
+            __gt__=lambda self, other: False
+        )
+
+        mock_get_with_context.return_value = Mock(status_code=404)
+
+        purefa_fs_module.main()
+
+        mock_create_fs.assert_called_once_with(mock_module, mock_array)
+        mock_check_renamed_fs.assert_not_called()


### PR DESCRIPTION
##### SUMMARY

`purefa_fs` recreates the file system it has just renamed.

`main()` guards its create branch against `move` but not against `rename`:

```python
if state == "present" and not exists and not module.params["move"]:
    create_fs(module, array)
```

A completed rename leaves nothing under the old name, so the second run of a
rename task falls into that branch and creates the source again. The array is
then left holding both file systems, and a third run fails outright.

Reproduced on a FlashArray running Purity//FA 6.10.6 (REST 2.54) with the
current `master`:

```
TASK [Rename source to target (run 1)] ***
changed: [localhost]

TASK [Rename source to target (run 2)] ***
changed: [localhost]

TASK [Report what the array now holds] ***
    "rename run 1 changed: True",
    "rename run 2 changed: True",
    "file systems: [..., 'ansible-bug-repro-dst', 'ansible-bug-repro-src']"

TASK [Rename a third time] ***
fatal: [localhost]: FAILED! => {"msg": "Target file system ansible-bug-repro-dst already exists"}
```

A rename whose source has gone is now resolved by looking for the target
rather than by creating anything:

| Source | Target | Result |
| --- | --- | --- |
| present | absent | rename, `changed` |
| present | present | fail, `Target file system ... already exists` (unchanged behaviour) |
| absent | present | **no change** - the rename has already happened |
| absent | destroyed | fail, `File system ... exists, but in destroyed state` |
| absent | absent | fail, `File system ... not found to rename` |

The pod qualified target name moves into a small `rename_target()` helper so
the rename itself and the second-run check cannot disagree about which name to
look for.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

purefa_fs

##### ADDITIONAL INFORMATION

Validated on the same array with a playbook that runs every action twice and
asserts the second run is a no-op:

```
TASK [Create must change once and then report no change] ***  ok
TASK [Check mode must predict the change without making it] ***  ok
TASK [Rename must change once and then report no change] ***  ok
TASK [The second run must not have recreated the source] ***  ok
TASK [A rename with nothing to rename must fail and create nothing] ***  ok

PLAY RECAP
localhost : ok=17  changed=4  unreachable=0  failed=0
```

The array was left holding exactly the file systems it started with, with
nothing in the trash.

Nine unit tests are added, covering `rename_target()` inside and outside a pod,
the four `check_renamed_fs()` outcomes, and the run-once/run-twice dispatch in
`main()`. The dispatch test was confirmed to fail against the old logic
(`check_renamed_fs` never reached, `create_fs` called instead) before the fix
was restored. `ansible-test sanity --local` passes on both changed files.

Renaming a file system inside a pod is covered by unit tests only - the
validation array carries live data, so no pod was created on it.

Not addressed here, but the same shape: `purefa_directory` guards its create
branch with a bare `if state == "present" and not exists:` and will recreate a
renamed directory in exactly the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
