### PR TITLE
fix(purefa_directory, purefa_policy): Make rename idempotent

### DIFF
--- a/changelogs/fragments/1051_rename_idempotency_directory_policy.yaml
+++ b/changelogs/fragments/1051_rename_idempotency_directory_policy.yaml
@@ -2,6 +2,9 @@ bugfixes:
   - purefa_directory - Fix rename so that re-running a rename task reports no
     change, instead of failing with a path collision or creating a duplicate
     directory under the original name.
+  - purefa_directory - Report a failure when the parent file system is
+    destroyed, rather than silently reporting no change for a rename that the
+    array would refuse.
   - purefa_policy - Fix rename so that re-running a rename task reports no
     change, instead of recreating the policy under its original name.
   - purefa_policy - Fix rename to report a change in check mode, rather than

--- a/changelogs/fragments/1051_rename_idempotency_directory_policy.yaml
+++ b/changelogs/fragments/1051_rename_idempotency_directory_policy.yaml
@@ -1,0 +1,8 @@
+bugfixes:
+  - purefa_directory - Fix rename so that re-running a rename task reports no
+    change, instead of failing with a path collision or creating a duplicate
+    directory under the original name.
+  - purefa_policy - Fix rename so that re-running a rename task reports no
+    change, instead of recreating the policy under its original name.
+  - purefa_policy - Fix rename to report a change in check mode, rather than
+    always reporting no change.

--- a/plugins/modules/purefa_directory.py
+++ b/plugins/modules/purefa_directory.py
@@ -48,6 +48,8 @@ options:
   rename:
     description:
     - Value to rename the specified directory to
+    - Re-running a rename task reports no change, as long as the directory
+      is already known by the new name.
     type: str
   context:
     description:
@@ -129,6 +131,39 @@ def delete_dir(module, array):
     module.exit_json(changed=changed)
 
 
+def rename_target(module):
+    """Return the fully qualified name a rename would give the directory"""
+    return module.params["filesystem"] + ":" + module.params["rename"]
+
+
+def check_renamed_dir(module, array):
+    """Report on a rename whose source directory has already gone
+
+    A completed rename leaves nothing under the old name, so a second run of
+    the same task must not create the source again - that would leave the file
+    system holding both the renamed directory and a fresh empty one.
+    """
+    target_name = rename_target(module)
+    res = get_with_context(
+        array,
+        "get_directories",
+        CONTEXT_VERSION,
+        module,
+        names=[target_name],
+    )
+    if res.status_code != 200:
+        module.fail_json(
+            msg="Directory {0} not found to rename".format(
+                module.params["filesystem"] + ":" + module.params["name"]
+            )
+        )
+    if list(res.items)[0].destroyed:
+        module.fail_json(
+            msg="Directory {0} exists, but in destroyed state".format(target_name)
+        )
+    module.exit_json(changed=False)
+
+
 def rename_dir(module, array):
     """Rename a file system directory"""
     changed = False
@@ -137,14 +172,12 @@ def rename_dir(module, array):
         "get_directories",
         CONTEXT_VERSION,
         module,
-        names=[module.params["filesystem"] + ":" + module.params["rename"]],
+        names=[rename_target(module)],
     )
     if target.status_code != 200:
         changed = True
         if not module.check_mode:
-            directory = flasharray.DirectoryPatch(
-                name=module.params["filesystem"] + ":" + module.params["rename"]
-            )
+            directory = flasharray.DirectoryPatch(name=rename_target(module))
             res = patch_with_context(
                 array,
                 "patch_directories",
@@ -247,7 +280,9 @@ def main():
     )
     exists = bool(res.status_code == 200)
 
-    if state == "present" and not exists:
+    if state == "present" and not exists and module.params["rename"]:
+        check_renamed_dir(module, array)
+    elif state == "present" and not exists:
         create_dir(module, array)
     elif (
         state == "present"

--- a/plugins/modules/purefa_directory.py
+++ b/plugins/modules/purefa_directory.py
@@ -157,10 +157,6 @@ def check_renamed_dir(module, array):
                 module.params["filesystem"] + ":" + module.params["name"]
             )
         )
-    if list(res.items)[0].destroyed:
-        module.fail_json(
-            msg="Directory {0} exists, but in destroyed state".format(target_name)
-        )
     module.exit_json(changed=False)
 
 
@@ -280,16 +276,22 @@ def main():
     )
     exists = bool(res.status_code == 200)
 
+    # Destroying a file system implicitly destroys the directories in it, and
+    # the array then refuses to create a directory ("File system has been
+    # destroyed.") or to rename one ("Managed directory cannot be renamed
+    # because it is implicitly destroyed."). Say so, rather than reporting no
+    # change and leaving the play believing the work was done.
+    if state == "present" and filesystem.destroyed:
+        module.fail_json(
+            msg="File system {0} is destroyed, so directories in it cannot be "
+            "created or renamed".format(module.params["filesystem"])
+        )
+
     if state == "present" and not exists and module.params["rename"]:
         check_renamed_dir(module, array)
     elif state == "present" and not exists:
         create_dir(module, array)
-    elif (
-        state == "present"
-        and exists
-        and module.params["rename"]
-        and not filesystem.destroyed
-    ):
+    elif state == "present" and exists and module.params["rename"]:
         rename_dir(module, array)
     elif state == "absent" and exists:
         delete_dir(module, array)

--- a/plugins/modules/purefa_policy.py
+++ b/plugins/modules/purefa_policy.py
@@ -124,6 +124,8 @@ options:
   rename:
     description:
     - New name of policy
+    - Re-running a rename task reports no change, as long as the policy is
+      already known by the new name.
     type: str
   directory:
     description:
@@ -531,6 +533,25 @@ MAX_PASSWORD_AGE_VERSION = "2.39"
 CA_VERSION = "2.43"
 
 
+def check_renamed_policy(module, array):
+    """Report on a rename whose source policy has already gone
+
+    A completed rename leaves nothing under the old name, so a second run of
+    the same task must not create the source again - that would leave the
+    array holding both the renamed policy and a fresh empty one.
+    """
+    res = get_with_context(
+        array, "get_policies", CONTEXT_VERSION, module, names=[module.params["rename"]]
+    )
+    if res.status_code != 200:
+        module.fail_json(msg=f"Policy {module.params['name']} not found to rename")
+    if list(res.items)[0].destroyed:
+        module.fail_json(
+            msg=f"Policy {module.params['rename']} exists, but in destroyed state"
+        )
+    module.exit_json(changed=False)
+
+
 def rename_policy(module, array):
     """Rename a file system policy"""
     changed = False
@@ -543,8 +564,8 @@ def rename_policy(module, array):
         module.fail_json(
             msg=f"Rename failed - Target policy {module.params['rename']} already exists"
         )
+    changed = True
     if not module.check_mode:
-        changed = True
         policy_type = module.params["policy"]
         policy_patch = PolicyPatch(name=module.params["rename"])
 
@@ -2603,7 +2624,9 @@ def main():
     all_squash = ALL_SQUASH_VERSION in api_version
     exists = bool(array.get_policies(names=[module.params["name"]]).status_code == 200)
 
-    if state == "present" and not exists:
+    if state == "present" and not exists and module.params["rename"]:
+        check_renamed_policy(module, array)
+    elif state == "present" and not exists:
         create_policy(module, array, all_squash)
     elif state == "present" and exists and module.params["rename"]:
         rename_policy(module, array)

--- a/tests/unit/plugins/modules/test_purefa_directory.py
+++ b/tests/unit/plugins/modules/test_purefa_directory.py
@@ -557,28 +557,6 @@ class TestCheckRenamedDir:
         assert "not found to rename" in mock_module.fail_json.call_args[1]["msg"]
         mock_module.exit_json.assert_not_called()
 
-    @patch("plugins.modules.purefa_directory.get_with_context")
-    def test_check_renamed_dir_target_destroyed_fails(self, mock_get):
-        """Test check_renamed_dir fails when the target is in the trash"""
-        mock_module = Mock()
-        mock_module.params = {
-            "filesystem": "fs1",
-            "name": "dir1",
-            "rename": "dir2",
-            "context": "",
-        }
-        mock_module.fail_json.side_effect = SystemExit(1)
-        mock_array = Mock()
-        mock_target = Mock()
-        mock_target.destroyed = True
-        mock_get.return_value = Mock(status_code=200, items=[mock_target])
-
-        with pytest.raises(SystemExit):
-            check_renamed_dir(mock_module, mock_array)
-
-        assert "destroyed state" in mock_module.fail_json.call_args[1]["msg"]
-        mock_module.exit_json.assert_not_called()
-
 
 class TestMainRenameIdempotency:
     """Test that a rename task run twice changes once and then reports no change"""
@@ -689,3 +667,105 @@ class TestMainRenameIdempotency:
 
         mock_create_dir.assert_called_once_with(mock_module, mock_array)
         mock_check_renamed_dir.assert_not_called()
+
+
+class TestMainDestroyedFilesystem:
+    """A destroyed file system must be reported, not silently ignored"""
+
+    @staticmethod
+    def _responses(dir_status):
+        fs_response = Mock(status_code=200)
+        fs_mock = Mock()
+        fs_mock.destroyed = True
+        fs_response.items = [fs_mock]
+        return [fs_response, Mock(status_code=dir_status)]
+
+    @patch("plugins.modules.purefa_directory.rename_dir")
+    @patch("plugins.modules.purefa_directory.get_with_context")
+    @patch("plugins.modules.purefa_directory.get_array")
+    @patch("plugins.modules.purefa_directory.AnsibleModule")
+    def test_main_rename_in_destroyed_filesystem_fails(
+        self, mock_ansible_module, mock_get_array, mock_get_with_context, mock_rename
+    ):
+        """Test a rename in a destroyed file system fails instead of no-oping"""
+        from plugins.modules.purefa_directory import main
+
+        mock_module = Mock()
+        mock_module.params = {
+            "state": "present",
+            "filesystem": "fs1",
+            "name": "dir1",
+            "path": None,
+            "rename": "dir2",
+            "context": "",
+        }
+        mock_module.fail_json.side_effect = SystemExit(1)
+        mock_ansible_module.return_value = mock_module
+        mock_get_array.return_value = Mock()
+        mock_get_with_context.side_effect = self._responses(200)
+
+        with pytest.raises(SystemExit):
+            main()
+
+        assert "is destroyed" in mock_module.fail_json.call_args[1]["msg"]
+        mock_rename.assert_not_called()
+
+    @patch("plugins.modules.purefa_directory.create_dir")
+    @patch("plugins.modules.purefa_directory.get_with_context")
+    @patch("plugins.modules.purefa_directory.get_array")
+    @patch("plugins.modules.purefa_directory.AnsibleModule")
+    def test_main_create_in_destroyed_filesystem_fails(
+        self, mock_ansible_module, mock_get_array, mock_get_with_context, mock_create
+    ):
+        """Test a create in a destroyed file system fails before the API call"""
+        from plugins.modules.purefa_directory import main
+
+        mock_module = Mock()
+        mock_module.params = {
+            "state": "present",
+            "filesystem": "fs1",
+            "name": "dir1",
+            "path": None,
+            "rename": None,
+            "context": "",
+        }
+        mock_module.fail_json.side_effect = SystemExit(1)
+        mock_ansible_module.return_value = mock_module
+        mock_get_array.return_value = Mock()
+        mock_get_with_context.side_effect = self._responses(404)
+
+        with pytest.raises(SystemExit):
+            main()
+
+        assert "is destroyed" in mock_module.fail_json.call_args[1]["msg"]
+        mock_create.assert_not_called()
+
+    @patch("plugins.modules.purefa_directory.delete_dir")
+    @patch("plugins.modules.purefa_directory.get_with_context")
+    @patch("plugins.modules.purefa_directory.get_array")
+    @patch("plugins.modules.purefa_directory.AnsibleModule")
+    def test_main_delete_in_destroyed_filesystem_still_works(
+        self, mock_ansible_module, mock_get_array, mock_get_with_context, mock_delete
+    ):
+        """Test the guard does not block removing a directory"""
+        from plugins.modules.purefa_directory import main
+
+        mock_module = Mock()
+        mock_module.params = {
+            "state": "absent",
+            "filesystem": "fs1",
+            "name": "dir1",
+            "path": None,
+            "rename": None,
+            "context": "",
+        }
+        mock_module.fail_json.side_effect = SystemExit(1)
+        mock_ansible_module.return_value = mock_module
+        mock_array = Mock()
+        mock_get_array.return_value = mock_array
+        mock_get_with_context.side_effect = self._responses(200)
+
+        main()
+
+        mock_delete.assert_called_once_with(mock_module, mock_array)
+        mock_module.fail_json.assert_not_called()

--- a/tests/unit/plugins/modules/test_purefa_directory.py
+++ b/tests/unit/plugins/modules/test_purefa_directory.py
@@ -47,6 +47,8 @@ sys.modules["ansible_collections.everpure.flasharray.plugins.module_utils.versio
 from plugins.modules.purefa_directory import (
     delete_dir,
     rename_dir,
+    rename_target,
+    check_renamed_dir,
     create_dir,
 )
 
@@ -494,3 +496,196 @@ class TestRenameCheckMode:
 
         # In check mode, should report changed=True but not make the patch call
         mock_module.exit_json.assert_called_once_with(changed=True)
+
+
+class TestRenameTarget:
+    """Test cases for rename_target function"""
+
+    def test_rename_target_qualifies_with_filesystem(self):
+        """Test rename_target prefixes the target with the file system"""
+        mock_module = Mock()
+        mock_module.params = {"filesystem": "fs1", "name": "dir1", "rename": "dir2"}
+
+        assert rename_target(mock_module) == "fs1:dir2"
+
+
+class TestCheckRenamedDir:
+    """Test cases for check_renamed_dir function
+
+    This is the second run of a rename task, when the source directory has
+    already gone.
+    """
+
+    @patch("plugins.modules.purefa_directory.get_with_context")
+    def test_check_renamed_dir_already_renamed(self, mock_get):
+        """Test check_renamed_dir reports no change once the target is there"""
+        mock_module = Mock()
+        mock_module.params = {
+            "filesystem": "fs1",
+            "name": "dir1",
+            "rename": "dir2",
+            "context": "",
+        }
+        mock_array = Mock()
+        mock_target = Mock()
+        mock_target.destroyed = False
+        mock_get.return_value = Mock(status_code=200, items=[mock_target])
+
+        check_renamed_dir(mock_module, mock_array)
+
+        assert mock_get.call_args[1]["names"] == ["fs1:dir2"]
+        mock_module.exit_json.assert_called_once_with(changed=False)
+        mock_module.fail_json.assert_not_called()
+
+    @patch("plugins.modules.purefa_directory.get_with_context")
+    def test_check_renamed_dir_neither_exists_fails(self, mock_get):
+        """Test check_renamed_dir fails rather than creating the source"""
+        mock_module = Mock()
+        mock_module.params = {
+            "filesystem": "fs1",
+            "name": "dir1",
+            "rename": "dir2",
+            "context": "",
+        }
+        mock_module.fail_json.side_effect = SystemExit(1)
+        mock_array = Mock()
+        mock_get.return_value = Mock(status_code=404)
+
+        with pytest.raises(SystemExit):
+            check_renamed_dir(mock_module, mock_array)
+
+        assert "not found to rename" in mock_module.fail_json.call_args[1]["msg"]
+        mock_module.exit_json.assert_not_called()
+
+    @patch("plugins.modules.purefa_directory.get_with_context")
+    def test_check_renamed_dir_target_destroyed_fails(self, mock_get):
+        """Test check_renamed_dir fails when the target is in the trash"""
+        mock_module = Mock()
+        mock_module.params = {
+            "filesystem": "fs1",
+            "name": "dir1",
+            "rename": "dir2",
+            "context": "",
+        }
+        mock_module.fail_json.side_effect = SystemExit(1)
+        mock_array = Mock()
+        mock_target = Mock()
+        mock_target.destroyed = True
+        mock_get.return_value = Mock(status_code=200, items=[mock_target])
+
+        with pytest.raises(SystemExit):
+            check_renamed_dir(mock_module, mock_array)
+
+        assert "destroyed state" in mock_module.fail_json.call_args[1]["msg"]
+        mock_module.exit_json.assert_not_called()
+
+
+class TestMainRenameIdempotency:
+    """Test that a rename task run twice changes once and then reports no change"""
+
+    @staticmethod
+    def _module(mock_ansible_module, rename="dir2"):
+        mock_module = Mock()
+        mock_module.params = {
+            "state": "present",
+            "filesystem": "fs1",
+            "name": "dir1",
+            "path": None,
+            "rename": rename,
+            "context": "",
+        }
+        mock_module.fail_json.side_effect = SystemExit(1)
+        mock_ansible_module.return_value = mock_module
+        return mock_module
+
+    @staticmethod
+    def _responses(dir_status):
+        fs_response = Mock(status_code=200)
+        fs_mock = Mock()
+        fs_mock.destroyed = False
+        fs_response.items = [fs_mock]
+        return [fs_response, Mock(status_code=dir_status)]
+
+    @patch("plugins.modules.purefa_directory.check_renamed_dir")
+    @patch("plugins.modules.purefa_directory.create_dir")
+    @patch("plugins.modules.purefa_directory.rename_dir")
+    @patch("plugins.modules.purefa_directory.get_with_context")
+    @patch("plugins.modules.purefa_directory.get_array")
+    @patch("plugins.modules.purefa_directory.AnsibleModule")
+    def test_main_rename_first_run_renames(
+        self,
+        mock_ansible_module,
+        mock_get_array,
+        mock_get_with_context,
+        mock_rename_dir,
+        mock_create_dir,
+        mock_check_renamed_dir,
+    ):
+        """First run: the source is there, so the rename happens"""
+        from plugins.modules.purefa_directory import main
+
+        mock_module = self._module(mock_ansible_module)
+        mock_array = Mock()
+        mock_get_array.return_value = mock_array
+        mock_get_with_context.side_effect = self._responses(200)
+
+        main()
+
+        mock_rename_dir.assert_called_once_with(mock_module, mock_array)
+        mock_create_dir.assert_not_called()
+        mock_check_renamed_dir.assert_not_called()
+
+    @patch("plugins.modules.purefa_directory.check_renamed_dir")
+    @patch("plugins.modules.purefa_directory.create_dir")
+    @patch("plugins.modules.purefa_directory.rename_dir")
+    @patch("plugins.modules.purefa_directory.get_with_context")
+    @patch("plugins.modules.purefa_directory.get_array")
+    @patch("plugins.modules.purefa_directory.AnsibleModule")
+    def test_main_rename_second_run_does_not_create(
+        self,
+        mock_ansible_module,
+        mock_get_array,
+        mock_get_with_context,
+        mock_rename_dir,
+        mock_create_dir,
+        mock_check_renamed_dir,
+    ):
+        """Second run: the source has gone, and must not be created again"""
+        from plugins.modules.purefa_directory import main
+
+        mock_module = self._module(mock_ansible_module)
+        mock_array = Mock()
+        mock_get_array.return_value = mock_array
+        mock_get_with_context.side_effect = self._responses(404)
+
+        main()
+
+        mock_check_renamed_dir.assert_called_once_with(mock_module, mock_array)
+        mock_create_dir.assert_not_called()
+        mock_rename_dir.assert_not_called()
+
+    @patch("plugins.modules.purefa_directory.check_renamed_dir")
+    @patch("plugins.modules.purefa_directory.create_dir")
+    @patch("plugins.modules.purefa_directory.get_with_context")
+    @patch("plugins.modules.purefa_directory.get_array")
+    @patch("plugins.modules.purefa_directory.AnsibleModule")
+    def test_main_creates_when_no_rename_requested(
+        self,
+        mock_ansible_module,
+        mock_get_array,
+        mock_get_with_context,
+        mock_create_dir,
+        mock_check_renamed_dir,
+    ):
+        """A missing directory with no rename asked for is still created"""
+        from plugins.modules.purefa_directory import main
+
+        mock_module = self._module(mock_ansible_module, rename=None)
+        mock_array = Mock()
+        mock_get_array.return_value = mock_array
+        mock_get_with_context.side_effect = self._responses(404)
+
+        main()
+
+        mock_create_dir.assert_called_once_with(mock_module, mock_array)
+        mock_check_renamed_dir.assert_not_called()

--- a/tests/unit/plugins/modules/test_purefa_policy.py
+++ b/tests/unit/plugins/modules/test_purefa_policy.py
@@ -324,8 +324,15 @@ class TestRenamePolicy:
 
     @patch("plugins.modules.purefa_policy.LooseVersion", side_effect=LooseVersion)
     @patch("plugins.modules.purefa_policy.PolicyPatch")
-    def test_rename_nfs_policy_check_mode(self, mock_policy_patch, mock_lv):
-        """Test rename_policy in check mode for NFS policy"""
+    @patch("plugins.modules.purefa_policy.patch_with_context")
+    def test_rename_nfs_policy_check_mode(
+        self, mock_patch_with_context, mock_policy_patch, mock_lv
+    ):
+        """Test rename_policy in check mode for NFS policy
+
+        Check mode has to predict the rename, so it reports changed while
+        leaving the array alone.
+        """
         mock_module = Mock()
         mock_module.params = {
             "name": "old_policy",
@@ -336,12 +343,11 @@ class TestRenamePolicy:
         mock_module.check_mode = True
         mock_array = Mock()
         mock_array.get_rest_version.return_value = "2.38"
-        # status_code == 200 means target name is available (can proceed)
-        mock_array.get_policies.return_value.status_code = 200
 
         rename_policy(mock_module, mock_array)
 
-        mock_module.exit_json.assert_called_once_with(changed=False)
+        mock_module.exit_json.assert_called_once_with(changed=True)
+        mock_patch_with_context.assert_not_called()
 
     @patch("plugins.modules.purefa_policy.LooseVersion", side_effect=LooseVersion)
     @patch("plugins.modules.purefa_policy.PolicyPatch")
@@ -4412,3 +4418,171 @@ class TestPasswordPolicyVersionGates:
 
         msgs = [c.kwargs.get("msg", "") for c in mock_module.fail_json.call_args_list]
         assert any("max_password_age" in m and "2.39" in m for m in msgs)
+
+
+class TestCheckRenamedPolicy:
+    """Test cases for check_renamed_policy function
+
+    This is the second run of a rename task, when the source policy has
+    already gone.
+    """
+
+    @patch("plugins.modules.purefa_policy.get_with_context")
+    def test_check_renamed_policy_already_renamed(self, mock_get):
+        """Test check_renamed_policy reports no change once the target is there"""
+        from plugins.modules.purefa_policy import check_renamed_policy
+
+        mock_module = Mock()
+        mock_module.params = {"name": "pol1", "rename": "pol2", "context": ""}
+        mock_array = Mock()
+        mock_target = Mock()
+        mock_target.destroyed = False
+        mock_get.return_value = Mock(status_code=200, items=[mock_target])
+
+        check_renamed_policy(mock_module, mock_array)
+
+        assert mock_get.call_args[1]["names"] == ["pol2"]
+        mock_module.exit_json.assert_called_once_with(changed=False)
+        mock_module.fail_json.assert_not_called()
+
+    @patch("plugins.modules.purefa_policy.get_with_context")
+    def test_check_renamed_policy_neither_exists_fails(self, mock_get):
+        """Test check_renamed_policy fails rather than creating the source"""
+        import pytest
+        from plugins.modules.purefa_policy import check_renamed_policy
+
+        mock_module = Mock()
+        mock_module.params = {"name": "pol1", "rename": "pol2", "context": ""}
+        mock_module.fail_json.side_effect = SystemExit(1)
+        mock_array = Mock()
+        mock_get.return_value = Mock(status_code=404)
+
+        with pytest.raises(SystemExit):
+            check_renamed_policy(mock_module, mock_array)
+
+        assert "not found to rename" in mock_module.fail_json.call_args[1]["msg"]
+        mock_module.exit_json.assert_not_called()
+
+    @patch("plugins.modules.purefa_policy.get_with_context")
+    def test_check_renamed_policy_target_destroyed_fails(self, mock_get):
+        """Test check_renamed_policy fails when the target is in the trash"""
+        import pytest
+        from plugins.modules.purefa_policy import check_renamed_policy
+
+        mock_module = Mock()
+        mock_module.params = {"name": "pol1", "rename": "pol2", "context": ""}
+        mock_module.fail_json.side_effect = SystemExit(1)
+        mock_array = Mock()
+        mock_target = Mock()
+        mock_target.destroyed = True
+        mock_get.return_value = Mock(status_code=200, items=[mock_target])
+
+        with pytest.raises(SystemExit):
+            check_renamed_policy(mock_module, mock_array)
+
+        assert "destroyed state" in mock_module.fail_json.call_args[1]["msg"]
+        mock_module.exit_json.assert_not_called()
+
+
+class TestMainRenameIdempotency:
+    """Test that a rename task run twice changes once and then reports no change"""
+
+    @staticmethod
+    def _module(mock_ansible_module, rename="new_policy"):
+        mock_module = Mock()
+        mock_module.params = {
+            "state": "present",
+            "policy": "nfs",
+            "name": "old_policy",
+            "rename": rename,
+            "nfs_access": "root-squash",
+            "quota_notifications": None,
+            "min_password_age": None,
+            "max_password_age": None,
+            "lockout_duration": None,
+            "context": "",
+        }
+        mock_module.check_mode = False
+        mock_module.fail_json.side_effect = SystemExit(1)
+        mock_ansible_module.return_value = mock_module
+        return mock_module
+
+    @staticmethod
+    def _array(mock_get_array, exists):
+        mock_array = Mock()
+        mock_array.get_rest_version.return_value = "2.44"
+        mock_array.get_policies.return_value.status_code = 200 if exists else 404
+        mock_get_array.return_value = mock_array
+        return mock_array
+
+    @patch("plugins.modules.purefa_policy.check_renamed_policy")
+    @patch("plugins.modules.purefa_policy.create_policy")
+    @patch("plugins.modules.purefa_policy.rename_policy")
+    @patch("plugins.modules.purefa_policy.get_array")
+    @patch("plugins.modules.purefa_policy.AnsibleModule")
+    def test_main_rename_first_run_renames(
+        self,
+        mock_ansible_module,
+        mock_get_array,
+        mock_rename_policy,
+        mock_create_policy,
+        mock_check_renamed_policy,
+    ):
+        """First run: the source is there, so the rename happens"""
+        from plugins.modules.purefa_policy import main
+
+        mock_module = self._module(mock_ansible_module)
+        mock_array = self._array(mock_get_array, exists=True)
+
+        main()
+
+        mock_rename_policy.assert_called_once_with(mock_module, mock_array)
+        mock_create_policy.assert_not_called()
+        mock_check_renamed_policy.assert_not_called()
+
+    @patch("plugins.modules.purefa_policy.check_renamed_policy")
+    @patch("plugins.modules.purefa_policy.create_policy")
+    @patch("plugins.modules.purefa_policy.rename_policy")
+    @patch("plugins.modules.purefa_policy.get_array")
+    @patch("plugins.modules.purefa_policy.AnsibleModule")
+    def test_main_rename_second_run_does_not_create(
+        self,
+        mock_ansible_module,
+        mock_get_array,
+        mock_rename_policy,
+        mock_create_policy,
+        mock_check_renamed_policy,
+    ):
+        """Second run: the source has gone, and must not be created again"""
+        from plugins.modules.purefa_policy import main
+
+        mock_module = self._module(mock_ansible_module)
+        mock_array = self._array(mock_get_array, exists=False)
+
+        main()
+
+        mock_check_renamed_policy.assert_called_once_with(mock_module, mock_array)
+        mock_create_policy.assert_not_called()
+        mock_rename_policy.assert_not_called()
+
+    @patch("plugins.modules.purefa_policy.check_renamed_policy")
+    @patch("plugins.modules.purefa_policy.create_policy")
+    @patch("plugins.modules.purefa_policy.get_array")
+    @patch("plugins.modules.purefa_policy.AnsibleModule")
+    def test_main_creates_when_no_rename_requested(
+        self,
+        mock_ansible_module,
+        mock_get_array,
+        mock_create_policy,
+        mock_check_renamed_policy,
+    ):
+        """A missing policy with no rename asked for is still created"""
+        from plugins.modules.purefa_policy import main
+
+        mock_module = self._module(mock_ansible_module, rename=None)
+        mock_array = self._array(mock_get_array, exists=False)
+
+        main()
+
+        assert mock_create_policy.call_args[0][:2] == (mock_module, mock_array)
+        mock_check_renamed_policy.assert_not_called()


### PR DESCRIPTION
##### SUMMARY

`purefa_directory` and `purefa_policy` carry the same rename bug that #1050
fixed in `purefa_fs`: the create branch is guarded only on the object being
absent, so the second run of a rename task finds nothing under the old name
and falls into create.

```python
if state == "present" and not exists:
    create_dir(module, array)          # or create_policy(...)
```

Both reproduced on a FlashArray running Purity//FA 6.10.6 (REST 2.54) with the
current `master`.

**`purefa_policy` - a duplicate policy.**

```
run 1: changed=True
run 2: changed=True
source policy still present: True
target policy present: True
```

**`purefa_directory` - it depends how the directory was created**, because a
rename does not move the directory's `path`. With `path` defaulted from the
name, `create_dir`'s collision check fires and the run fails with a message
that points at the wrong thing entirely:

```
TASK [Rename directory (run 2)] ***
fatal: [localhost]: FAILED! => {"msg": "Path ansible-repro-dir-src already existis in file system ansible-repro-fs"}
directories: ['root', 'ansible-repro-dir-dst']
```

With a custom `path` there is no collision, so the second run creates a real
duplicate:

```
run 1: changed=True
run 2: changed=True
directories: ['root', 'ansible-repro2-dst', 'ansible-repro2-src']
```

A rename whose source has gone is now resolved by looking for the target
rather than by creating anything, matching `purefa_fs`:

| Source | Target | Result |
| --- | --- | --- |
| present | absent | rename, `changed` |
| present | present | fail, target already exists (unchanged behaviour) |
| absent | present | **no change** - the rename has already happened |
| absent | absent | fail, `... not found to rename` |

`purefa_policy` also fails if the target is destroyed. `purefa_directory` does
not need that case - see below.

##### Second bug: a destroyed parent file system was ignored

`purefa_directory`'s rename branch was guarded by `not filesystem.destroyed`,
which refers to the parent *file system*, not the directory. A rename asked for
while the parent was destroyed matched no branch at all and fell through to
`exit_json(changed=False)` - the play was told the work was done when nothing
had happened:

```
TASK [Rename a directory in the destroyed file system] ***
ok: [localhost]
rename: failed=False changed=False msg=none
```

Established against the array rather than assumed:

* destroying a file system implicitly destroys its directories, and recovering
  it restores them, so a directory's `destroyed` state always tracks its parent
* a managed directory cannot be destroyed on its own - `delete_directories`
  removes it outright and there is no per-directory trash
* a rename inside a destroyed file system is refused with `Managed directory
  cannot be renamed because it is implicitly destroyed.`, and a create with
  `File system has been destroyed.`
* removing a directory while the parent is destroyed **is** allowed

Since every `state: present` operation is refused by the array, `main()` now
says so up front rather than guarding a single branch:

```
rename: File system ansible-dest-fs is destroyed, so directories in it cannot be created or renamed
create: File system ansible-dest-fs is destroyed, so directories in it cannot be created or renamed
```

Create previously reached the array and failed there, which was at least
honest; it now fails with the same clear message. `state: absent` is untouched
and still removes the directory.

That also makes a destroyed-target check inside `check_renamed_dir` unreachable
- a directory is only ever destroyed along with its parent - so it is removed
rather than left as dead code. `purefa_policy` keeps its equivalent check:
policies carry a `pod`, so a destroyed policy is plausible there, and reporting
"no change" for one would be wrong. That path is defensive and was not
exercised on hardware.

##### Third, smaller bug: `rename_policy` in check mode

`rename_policy` set its `changed` flag *inside* the `if not module.check_mode`
branch, so check mode always reported `changed=False` - a play could not see a
pending rename at all:

```
check mode before rename: changed=False
```

The assignment moves outside that branch. One existing unit test asserted the
old behaviour (`exit_json(changed=False)`) and is corrected here, with an added
assertion that check mode still patches nothing.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

purefa_directory
purefa_policy

##### ADDITIONAL INFORMATION

Validated on the same array with playbooks that run every action twice and
assert the second run is a no-op, covering both modules, the custom `path`
variant, check mode, the nothing-to-rename failure, and the destroyed parent:

```
TASK [Directory create must change once then report no change] ***  ok
TASK [Directory check mode must predict without acting] ***  ok
TASK [Directory rename must change once then report no change] ***  ok
TASK [The second directory run must not have recreated the source] ***  ok
TASK [A directory rename with nothing to rename must fail and create nothing] ***  ok
TASK [Custom path rename must change once and not duplicate] ***  ok
TASK [Policy create must change once then report no change] ***  ok
TASK [Policy check mode must predict without acting] ***  ok
TASK [Policy rename must change once then report no change] ***  ok
TASK [The second policy run must not have recreated the source] ***  ok
TASK [A policy rename with nothing to rename must fail and create nothing] ***  ok

PLAY RECAP
localhost : ok=40  changed=12  unreachable=0  failed=0
```

```
TASK [Both must fail with a message naming the file system] ***  ok
TASK [Recovery must restore normal idempotent renaming] ***  ok
TASK [The delete must be allowed] ***  ok

PLAY RECAP
localhost : ok=19  changed=9  unreachable=0  failed=0
```

The array's file systems, policies and directories were byte-identical to the
baseline taken before the runs, with nothing left in the trash. Everything the
plays touched they created and removed.

Fourteen unit tests are added: `rename_target()`, the `check_renamed_dir()` and
`check_renamed_policy()` outcomes, run-once/run-twice dispatch tests for both
`main()` functions, and three destroyed-file-system cases including that
`state: absent` is still allowed through. `purefa_policy` had no `main()` tests
at all before this. Both dispatch tests were confirmed to fail against the old
logic (`check_renamed_dir` / `check_renamed_policy` never reached, create called
instead) before the fix was restored. `ansible-test sanity --local` passes on
all four files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
