### PR TITLE
feat(purefa_lds): Add module to manage local directory services

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ All modules are idempotent with the exception of modules that change or set pass
 - purefa_host - manage hosts on the FlashArray
 - purefa_info - get information regarding the configuration of the Flasharray
 - purefa_inventory - get hardware inventory information from a FlashArray
+- purefa_lds - manage the Local Directory Services of the FlashArray
 - purefa_logging - get audit and session logs from a FlashArray
 - purefa_maintenance - manage FlashArray maintenance windows
 - purefa_messages - list FlashArray alert messages

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -33,6 +33,7 @@ action_groups:
    - purefa_info
    - purefa_inventory
    - purefa_kmip
+   - purefa_lds
    - purefa_logging
    - purefa_maintenance
    - purefa_messages

--- a/plugins/modules/purefa_lds.py
+++ b/plugins/modules/purefa_lds.py
@@ -182,7 +182,9 @@ def create_lds(module, array):
         check_response(
             res,
             module,
-            f"Failed to create local directory service {module.params['name']}",
+            "Failed to create local directory service {0}".format(
+                module.params["name"]
+            ),
         )
     module.exit_json(changed=True)
 
@@ -207,8 +209,8 @@ def update_lds(module, array, lds):
         check_response(
             res,
             module,
-            f"Failed to change the domain of local directory service "
-            f"{module.params['name']}",
+            "Failed to change the domain of local directory service "
+            "{0}".format(module.params["name"]),
         )
     module.exit_json(changed=changed)
 
@@ -233,7 +235,9 @@ def rename_lds(module, array):
         check_response(
             res,
             module,
-            f"Failed to rename local directory service {module.params['name']}",
+            "Failed to rename local directory service {0}".format(
+                module.params["name"]
+            ),
         )
     module.exit_json(changed=True)
 
@@ -267,7 +271,9 @@ def delete_lds(module, array):
         check_response(
             res,
             module,
-            f"Failed to delete local directory service {module.params['name']}",
+            "Failed to delete local directory service {0}".format(
+                module.params["name"]
+            ),
         )
     module.exit_json(changed=True)
 

--- a/plugins/modules/purefa_lds.py
+++ b/plugins/modules/purefa_lds.py
@@ -1,0 +1,314 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2026, Simon Dodsley (simon@everpuredata.com)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+DOCUMENTATION = r"""
+---
+module: purefa_lds
+version_added: '1.45.0'
+short_description: Manage Everpure FlashArray local directory services
+description:
+- Create, rename, reconfigure and delete local directory services on Everpure
+  FlashArrays.
+- A local directory service holds users and groups on the array itself, for
+  file serving that does not authenticate against an external directory. It is
+  attached to a file server, which is managed by
+  M(everpure.flasharray.purefa_server).
+- Every local directory service is created with its own built-in users and
+  groups - C(Administrator) and C(Guest), and the C(Administrators),
+  C(Guests), C(Backup Operators) and C(Audit Operators) groups. Those cannot be
+  deleted, and their names are therefore repeated in every local directory
+  service on the array.
+- External directory services are managed by
+  M(everpure.flasharray.purefa_ds).
+author:
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@everpuredata.com>
+options:
+  name:
+    description:
+    - Name of the local directory service
+    type: str
+    required: true
+  state:
+    description:
+    - Define whether the local directory service should exist or not.
+    - Deleting a local directory service also deletes every user and group it
+      holds. See the note on I(state=absent).
+    default: present
+    choices: [ absent, present ]
+    type: str
+  domain:
+    description:
+    - Domain name the local directory service serves.
+    - The array defaults this to the name of the local directory service when
+      it is created without one.
+    - Two local directory services may share a domain.
+    type: str
+  rename:
+    description:
+    - Value to rename the specified local directory service to
+    - Re-running a rename task reports no change, as long as the local
+      directory service is already known by the new name.
+    type: str
+  context:
+    description:
+    - Name of fleet member on which to perform the operation.
+    - This requires the array receiving the request is a member of a fleet
+      and the context name to be a member of the same fleet.
+    type: str
+    default: ""
+extends_documentation_fragment:
+- everpure.flasharray.everpure.fa
+notes:
+- Supported from Purity//FA 6.8.0 or higher.
+- Deleting a local directory service is not recoverable. The array removes
+  every user and group inside it at the same time, including any password set
+  on those users.
+- A local directory service that is in use by a file server cannot be deleted.
+  Detach it with M(everpure.flasharray.purefa_server) first.
+"""
+
+EXAMPLES = r"""
+- name: Create local directory service foo
+  everpure.flasharray.purefa_lds:
+    name: foo
+    domain: foo.example.com
+    fa_url: 10.10.10.2
+    api_token: e31060a7-21fc-e277-6240-25983c6c4592
+
+- name: Create local directory service bar, letting the array set the domain
+  everpure.flasharray.purefa_lds:
+    name: bar
+    fa_url: 10.10.10.2
+    api_token: e31060a7-21fc-e277-6240-25983c6c4592
+
+- name: Change the domain of local directory service foo
+  everpure.flasharray.purefa_lds:
+    name: foo
+    domain: new.example.com
+    fa_url: 10.10.10.2
+    api_token: e31060a7-21fc-e277-6240-25983c6c4592
+
+- name: Rename local directory service foo to bar
+  everpure.flasharray.purefa_lds:
+    name: foo
+    rename: bar
+    fa_url: 10.10.10.2
+    api_token: e31060a7-21fc-e277-6240-25983c6c4592
+
+- name: Delete local directory service foo and everything in it
+  everpure.flasharray.purefa_lds:
+    name: foo
+    state: absent
+    fa_url: 10.10.10.2
+    api_token: e31060a7-21fc-e277-6240-25983c6c4592
+"""
+
+RETURN = r"""
+"""
+
+HAS_PURESTORAGE = True
+try:
+    from pypureclient.flasharray import (
+        LocalDirectoryService,
+        LocalDirectoryServicePost,
+    )
+except ImportError:
+    HAS_PURESTORAGE = False
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.everpure.flasharray.plugins.module_utils.purefa import (
+    get_array,
+    purefa_argument_spec,
+)
+from ansible_collections.everpure.flasharray.plugins.module_utils.api_helpers import (
+    check_api_version,
+    check_response,
+    delete_with_context,
+    get_with_context,
+    patch_with_context,
+    post_with_context,
+)
+
+# Local directory services became manageable in their own right in this
+# version. The users and groups inside them go back to 2.21, but there is no
+# way to address the containing service before this.
+LDS_API_VERSION = "2.44"
+CONTEXT_VERSION = "2.38"
+
+
+def read_lds(module, array, name):
+    """Return the named local directory service, or None
+
+    A name the array does not have comes back as 400, not 404, so anything
+    other than 200 counts as absent.
+    """
+    res = get_with_context(
+        array,
+        "get_directory_services_local_directory_services",
+        CONTEXT_VERSION,
+        module,
+        names=[name],
+    )
+    if res.status_code != 200:
+        return None
+    return next(iter(list(res.items)), None)
+
+
+def create_lds(module, array):
+    """Create a local directory service"""
+    if not module.check_mode:
+        local_directory = LocalDirectoryServicePost(domain=module.params["domain"])
+        res = post_with_context(
+            array,
+            "post_directory_services_local_directory_services",
+            CONTEXT_VERSION,
+            module,
+            names=[module.params["name"]],
+            local_directory=local_directory,
+        )
+        check_response(
+            res,
+            module,
+            f"Failed to create local directory service {module.params['name']}",
+        )
+    module.exit_json(changed=True)
+
+
+def update_lds(module, array, lds):
+    """Bring the domain of an existing local directory service into line
+
+    An omitted domain leaves whatever the array already has, which is what
+    makes a play that only names the service idempotent.
+    """
+    wanted = module.params["domain"]
+    changed = bool(wanted) and wanted != getattr(lds, "domain", None)
+    if changed and not module.check_mode:
+        res = patch_with_context(
+            array,
+            "patch_directory_services_local_directory_services",
+            CONTEXT_VERSION,
+            module,
+            names=[module.params["name"]],
+            local_directory=LocalDirectoryService(domain=wanted),
+        )
+        check_response(
+            res,
+            module,
+            f"Failed to change the domain of local directory service "
+            f"{module.params['name']}",
+        )
+    module.exit_json(changed=changed)
+
+
+def rename_lds(module, array):
+    """Rename a local directory service"""
+    if read_lds(module, array, module.params["rename"]):
+        module.fail_json(
+            msg="Target local directory service {0} already exists".format(
+                module.params["rename"]
+            )
+        )
+    if not module.check_mode:
+        res = patch_with_context(
+            array,
+            "patch_directory_services_local_directory_services",
+            CONTEXT_VERSION,
+            module,
+            names=[module.params["name"]],
+            local_directory=LocalDirectoryService(name=module.params["rename"]),
+        )
+        check_response(
+            res,
+            module,
+            f"Failed to rename local directory service {module.params['name']}",
+        )
+    module.exit_json(changed=True)
+
+
+def check_renamed_lds(module, array):
+    """Report on a rename whose source has already gone
+
+    A completed rename leaves nothing under the old name, so a second run of
+    the same task must not create the source again - that would leave the array
+    holding both the renamed service and a fresh empty one.
+    """
+    if not read_lds(module, array, module.params["rename"]):
+        module.fail_json(
+            msg="Local directory service {0} not found to rename".format(
+                module.params["name"]
+            )
+        )
+    module.exit_json(changed=False)
+
+
+def delete_lds(module, array):
+    """Delete a local directory service, and everything inside it"""
+    if not module.check_mode:
+        res = delete_with_context(
+            array,
+            "delete_directory_services_local_directory_services",
+            CONTEXT_VERSION,
+            module,
+            names=[module.params["name"]],
+        )
+        check_response(
+            res,
+            module,
+            f"Failed to delete local directory service {module.params['name']}",
+        )
+    module.exit_json(changed=True)
+
+
+def main():
+    argument_spec = purefa_argument_spec()
+    argument_spec.update(
+        dict(
+            state=dict(type="str", default="present", choices=["absent", "present"]),
+            name=dict(type="str", required=True),
+            domain=dict(type="str"),
+            rename=dict(type="str"),
+            context=dict(type="str", default=""),
+        )
+    )
+
+    module = AnsibleModule(argument_spec, supports_check_mode=True)
+
+    if not HAS_PURESTORAGE:
+        module.fail_json(msg="py-pure-client sdk is required for this module")
+
+    array = get_array(module)
+    check_api_version(array, LDS_API_VERSION, module, "Local directory services")
+
+    state = module.params["state"]
+    lds = read_lds(module, array, module.params["name"])
+
+    if state == "present" and module.params["rename"]:
+        if lds:
+            rename_lds(module, array)
+        else:
+            check_renamed_lds(module, array)
+    elif state == "present" and not lds:
+        create_lds(module, array)
+    elif state == "present":
+        update_lds(module, array, lds)
+    elif state == "absent" and lds:
+        delete_lds(module, array)
+
+    module.exit_json(changed=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -83,6 +83,7 @@ plugins/modules/purefa_host.py import-2.7
 plugins/modules/purefa_info.py import-2.7
 plugins/modules/purefa_inventory.py import-2.7
 plugins/modules/purefa_kmip.py import-2.7
+plugins/modules/purefa_lds.py import-2.7
 plugins/modules/purefa_logging.py import-2.7
 plugins/modules/purefa_maintenance.py import-2.7
 plugins/modules/purefa_messages.py import-2.7

--- a/tests/unit/plugins/modules/test_purefa_lds.py
+++ b/tests/unit/plugins/modules/test_purefa_lds.py
@@ -1,0 +1,453 @@
+# Copyright: (c) 2026, Everpure Ansible Team <pure-ansible-team@everpuredata.com>
+# GNU General Public License v3.0+ (see COPYING.GPLv3 or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for purefa_lds module."""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import sys
+from unittest.mock import Mock, MagicMock, patch
+
+import pytest
+
+# Mock external dependencies before importing module
+sys.modules["grp"] = MagicMock()
+sys.modules["pwd"] = MagicMock()
+sys.modules["fcntl"] = MagicMock()
+sys.modules["ansible"] = MagicMock()
+sys.modules["ansible.module_utils"] = MagicMock()
+sys.modules["ansible.module_utils.basic"] = MagicMock()
+sys.modules["pypureclient"] = MagicMock()
+sys.modules["pypureclient.flasharray"] = MagicMock()
+sys.modules["ansible_collections"] = MagicMock()
+sys.modules["ansible_collections.everpure"] = MagicMock()
+sys.modules["ansible_collections.everpure.flasharray"] = MagicMock()
+sys.modules["ansible_collections.everpure.flasharray.plugins"] = MagicMock()
+sys.modules["ansible_collections.everpure.flasharray.plugins.module_utils"] = (
+    MagicMock()
+)
+sys.modules["ansible_collections.everpure.flasharray.plugins.module_utils.purefa"] = (
+    MagicMock()
+)
+sys.modules[
+    "ansible_collections.everpure.flasharray.plugins.module_utils.api_helpers"
+] = MagicMock()
+
+from plugins.modules.purefa_lds import (
+    read_lds,
+    create_lds,
+    update_lds,
+    rename_lds,
+    check_renamed_lds,
+    delete_lds,
+)
+
+
+def make_module(**params):
+    """An AnsibleModule stand-in whose fail_json raises, as the real one does"""
+    module = Mock()
+    module.check_mode = False
+    base = {
+        "name": "lds1",
+        "domain": None,
+        "rename": None,
+        "state": "present",
+        "context": "",
+    }
+    base.update(params)
+    module.params = base
+    module.fail_json.side_effect = SystemExit(1)
+    return module
+
+
+class TestReadLds:
+    """Test cases for read_lds function"""
+
+    @patch("plugins.modules.purefa_lds.get_with_context")
+    def test_read_lds_found(self, mock_get):
+        """Test read_lds returns the service the array holds"""
+        module = make_module()
+        lds = Mock()
+        lds.name = "lds1"
+        mock_get.return_value = Mock(status_code=200, items=[lds])
+
+        assert read_lds(module, Mock(), "lds1") is lds
+        assert mock_get.call_args[1]["names"] == ["lds1"]
+
+    @patch("plugins.modules.purefa_lds.get_with_context")
+    def test_read_lds_absent_is_400_not_404(self, mock_get):
+        """Test read_lds treats the array's 400 for an unknown name as absent
+
+        The array answers a name it does not have with 400, so anything other
+        than 200 has to count as absent.
+        """
+        module = make_module()
+        mock_get.return_value = Mock(status_code=400)
+
+        assert read_lds(module, Mock(), "nope") is None
+
+    @patch("plugins.modules.purefa_lds.get_with_context")
+    def test_read_lds_empty_items(self, mock_get):
+        """Test read_lds copes with a 200 that carries nothing"""
+        module = make_module()
+        mock_get.return_value = Mock(status_code=200, items=[])
+
+        assert read_lds(module, Mock(), "lds1") is None
+
+
+class TestCreateLds:
+    """Test cases for create_lds function"""
+
+    def test_create_lds_check_mode(self):
+        """Test create_lds predicts the change without calling the array"""
+        module = make_module(domain="a.example")
+        module.check_mode = True
+
+        create_lds(module, Mock())
+
+        module.exit_json.assert_called_once_with(changed=True)
+
+    @patch("plugins.modules.purefa_lds.check_response")
+    @patch("plugins.modules.purefa_lds.post_with_context")
+    def test_create_lds_success(self, mock_post, mock_check):
+        """Test create_lds posts the name and reports a change"""
+        module = make_module(domain="a.example")
+        mock_post.return_value = Mock(status_code=200)
+
+        create_lds(module, Mock())
+
+        assert mock_post.call_args[1]["names"] == ["lds1"]
+        module.exit_json.assert_called_once_with(changed=True)
+
+    @patch("plugins.modules.purefa_lds.check_response")
+    @patch("plugins.modules.purefa_lds.post_with_context")
+    def test_create_lds_without_domain(self, mock_post, mock_check):
+        """Test create_lds still creates when no domain is given
+
+        The array defaults the domain to the name of the service.
+        """
+        module = make_module()
+        mock_post.return_value = Mock(status_code=200)
+
+        create_lds(module, Mock())
+
+        mock_post.assert_called_once()
+        module.exit_json.assert_called_once_with(changed=True)
+
+
+class TestUpdateLds:
+    """Test cases for update_lds function"""
+
+    @patch("plugins.modules.purefa_lds.patch_with_context")
+    def test_update_lds_no_domain_requested(self, mock_patch):
+        """Test an omitted domain is not treated as a change"""
+        module = make_module()
+        lds = Mock()
+        lds.domain = "current.example"
+
+        update_lds(module, Mock(), lds)
+
+        mock_patch.assert_not_called()
+        module.exit_json.assert_called_once_with(changed=False)
+
+    @patch("plugins.modules.purefa_lds.patch_with_context")
+    def test_update_lds_domain_already_correct(self, mock_patch):
+        """Test a matching domain reports no change"""
+        module = make_module(domain="same.example")
+        lds = Mock()
+        lds.domain = "same.example"
+
+        update_lds(module, Mock(), lds)
+
+        mock_patch.assert_not_called()
+        module.exit_json.assert_called_once_with(changed=False)
+
+    @patch("plugins.modules.purefa_lds.check_response")
+    @patch("plugins.modules.purefa_lds.patch_with_context")
+    def test_update_lds_domain_changed(self, mock_patch, mock_check):
+        """Test a differing domain is patched"""
+        module = make_module(domain="new.example")
+        lds = Mock()
+        lds.domain = "old.example"
+        mock_patch.return_value = Mock(status_code=200)
+
+        update_lds(module, Mock(), lds)
+
+        assert mock_patch.call_args[1]["names"] == ["lds1"]
+        module.exit_json.assert_called_once_with(changed=True)
+
+    @patch("plugins.modules.purefa_lds.patch_with_context")
+    def test_update_lds_check_mode(self, mock_patch):
+        """Test update_lds predicts a domain change without making it"""
+        module = make_module(domain="new.example")
+        module.check_mode = True
+        lds = Mock()
+        lds.domain = "old.example"
+
+        update_lds(module, Mock(), lds)
+
+        mock_patch.assert_not_called()
+        module.exit_json.assert_called_once_with(changed=True)
+
+
+class TestRenameLds:
+    """Test cases for rename_lds function"""
+
+    @patch("plugins.modules.purefa_lds.check_response")
+    @patch("plugins.modules.purefa_lds.patch_with_context")
+    @patch("plugins.modules.purefa_lds.read_lds")
+    def test_rename_lds_success(self, mock_read, mock_patch, mock_check):
+        """Test rename_lds patches the new name when it is free"""
+        module = make_module(rename="lds2")
+        mock_read.return_value = None
+        mock_patch.return_value = Mock(status_code=200)
+
+        rename_lds(module, Mock())
+
+        assert mock_patch.call_args[1]["names"] == ["lds1"]
+        module.exit_json.assert_called_once_with(changed=True)
+
+    @patch("plugins.modules.purefa_lds.patch_with_context")
+    @patch("plugins.modules.purefa_lds.read_lds")
+    def test_rename_lds_target_exists_fails(self, mock_read, mock_patch):
+        """Test rename_lds refuses to rename onto an existing service"""
+        module = make_module(rename="lds2")
+        mock_read.return_value = Mock()
+
+        with pytest.raises(SystemExit):
+            rename_lds(module, Mock())
+
+        assert "already exists" in module.fail_json.call_args[1]["msg"]
+        mock_patch.assert_not_called()
+
+    @patch("plugins.modules.purefa_lds.patch_with_context")
+    @patch("plugins.modules.purefa_lds.read_lds")
+    def test_rename_lds_check_mode(self, mock_read, mock_patch):
+        """Test rename_lds predicts the rename without making it"""
+        module = make_module(rename="lds2")
+        module.check_mode = True
+        mock_read.return_value = None
+
+        rename_lds(module, Mock())
+
+        mock_patch.assert_not_called()
+        module.exit_json.assert_called_once_with(changed=True)
+
+
+class TestCheckRenamedLds:
+    """Test cases for check_renamed_lds function
+
+    This is the second run of a rename task, when the source has already gone.
+    """
+
+    @patch("plugins.modules.purefa_lds.read_lds")
+    def test_check_renamed_lds_already_renamed(self, mock_read):
+        """Test no change is reported once the target is there"""
+        module = make_module(rename="lds2")
+        mock_read.return_value = Mock()
+
+        check_renamed_lds(module, Mock())
+
+        module.exit_json.assert_called_once_with(changed=False)
+        module.fail_json.assert_not_called()
+
+    @patch("plugins.modules.purefa_lds.read_lds")
+    def test_check_renamed_lds_neither_exists_fails(self, mock_read):
+        """Test a rename with nothing to rename fails instead of creating"""
+        module = make_module(rename="lds2")
+        mock_read.return_value = None
+
+        with pytest.raises(SystemExit):
+            check_renamed_lds(module, Mock())
+
+        assert "not found to rename" in module.fail_json.call_args[1]["msg"]
+        module.exit_json.assert_not_called()
+
+
+class TestDeleteLds:
+    """Test cases for delete_lds function"""
+
+    def test_delete_lds_check_mode(self):
+        """Test delete_lds predicts the change without calling the array"""
+        module = make_module(state="absent")
+        module.check_mode = True
+
+        delete_lds(module, Mock())
+
+        module.exit_json.assert_called_once_with(changed=True)
+
+    @patch("plugins.modules.purefa_lds.check_response")
+    @patch("plugins.modules.purefa_lds.delete_with_context")
+    def test_delete_lds_success(self, mock_delete, mock_check):
+        """Test delete_lds deletes by name and reports a change"""
+        module = make_module(state="absent")
+        mock_delete.return_value = Mock(status_code=200)
+
+        delete_lds(module, Mock())
+
+        assert mock_delete.call_args[1]["names"] == ["lds1"]
+        module.exit_json.assert_called_once_with(changed=True)
+
+
+class TestMain:
+    """Test cases for the main dispatch"""
+
+    @patch("plugins.modules.purefa_lds.get_array")
+    @patch("plugins.modules.purefa_lds.AnsibleModule")
+    def test_main_no_purestorage_sdk(self, mock_ansible_module, mock_get_array):
+        """Test main fails when py-pure-client is missing"""
+        import plugins.modules.purefa_lds as mod
+
+        original = mod.HAS_PURESTORAGE
+        mod.HAS_PURESTORAGE = False
+        module = make_module()
+        mock_ansible_module.return_value = module
+        try:
+            with pytest.raises(SystemExit):
+                mod.main()
+            assert "sdk is required" in module.fail_json.call_args[1]["msg"]
+        finally:
+            mod.HAS_PURESTORAGE = original
+
+    @staticmethod
+    def _wire(mock_ansible_module, mock_get_array, **params):
+        module = make_module(**params)
+        mock_ansible_module.return_value = module
+        array = Mock()
+        mock_get_array.return_value = array
+        return module, array
+
+    @patch("plugins.modules.purefa_lds.create_lds")
+    @patch("plugins.modules.purefa_lds.read_lds")
+    @patch("plugins.modules.purefa_lds.check_api_version")
+    @patch("plugins.modules.purefa_lds.get_array")
+    @patch("plugins.modules.purefa_lds.AnsibleModule")
+    def test_main_creates_when_absent(
+        self, mock_am, mock_ga, mock_check_api, mock_read, mock_create
+    ):
+        """Test main creates a service the array does not have"""
+        import plugins.modules.purefa_lds as mod
+
+        module, array = self._wire(mock_am, mock_ga)
+        mock_read.return_value = None
+
+        mod.main()
+
+        mock_create.assert_called_once_with(module, array)
+        mock_check_api.assert_called_once()
+
+    @patch("plugins.modules.purefa_lds.update_lds")
+    @patch("plugins.modules.purefa_lds.read_lds")
+    @patch("plugins.modules.purefa_lds.check_api_version")
+    @patch("plugins.modules.purefa_lds.get_array")
+    @patch("plugins.modules.purefa_lds.AnsibleModule")
+    def test_main_updates_when_present(
+        self, mock_am, mock_ga, mock_check_api, mock_read, mock_update
+    ):
+        """Test main reconciles a service that is already there"""
+        import plugins.modules.purefa_lds as mod
+
+        module, array = self._wire(mock_am, mock_ga, domain="a.example")
+        lds = Mock()
+        mock_read.return_value = lds
+
+        mod.main()
+
+        mock_update.assert_called_once_with(module, array, lds)
+
+    @patch("plugins.modules.purefa_lds.check_renamed_lds")
+    @patch("plugins.modules.purefa_lds.create_lds")
+    @patch("plugins.modules.purefa_lds.rename_lds")
+    @patch("plugins.modules.purefa_lds.read_lds")
+    @patch("plugins.modules.purefa_lds.check_api_version")
+    @patch("plugins.modules.purefa_lds.get_array")
+    @patch("plugins.modules.purefa_lds.AnsibleModule")
+    def test_main_rename_first_run(
+        self,
+        mock_am,
+        mock_ga,
+        mock_check_api,
+        mock_read,
+        mock_rename,
+        mock_create,
+        mock_checked,
+    ):
+        """First run: the source is there, so the rename happens"""
+        import plugins.modules.purefa_lds as mod
+
+        module, array = self._wire(mock_am, mock_ga, rename="lds2")
+        mock_read.return_value = Mock()
+
+        mod.main()
+
+        mock_rename.assert_called_once_with(module, array)
+        mock_create.assert_not_called()
+        mock_checked.assert_not_called()
+
+    @patch("plugins.modules.purefa_lds.check_renamed_lds")
+    @patch("plugins.modules.purefa_lds.create_lds")
+    @patch("plugins.modules.purefa_lds.rename_lds")
+    @patch("plugins.modules.purefa_lds.read_lds")
+    @patch("plugins.modules.purefa_lds.check_api_version")
+    @patch("plugins.modules.purefa_lds.get_array")
+    @patch("plugins.modules.purefa_lds.AnsibleModule")
+    def test_main_rename_second_run_does_not_create(
+        self,
+        mock_am,
+        mock_ga,
+        mock_check_api,
+        mock_read,
+        mock_rename,
+        mock_create,
+        mock_checked,
+    ):
+        """Second run: the source has gone, and must not be created again"""
+        import plugins.modules.purefa_lds as mod
+
+        module, array = self._wire(mock_am, mock_ga, rename="lds2")
+        mock_read.return_value = None
+
+        mod.main()
+
+        mock_checked.assert_called_once_with(module, array)
+        mock_create.assert_not_called()
+        mock_rename.assert_not_called()
+
+    @patch("plugins.modules.purefa_lds.delete_lds")
+    @patch("plugins.modules.purefa_lds.read_lds")
+    @patch("plugins.modules.purefa_lds.check_api_version")
+    @patch("plugins.modules.purefa_lds.get_array")
+    @patch("plugins.modules.purefa_lds.AnsibleModule")
+    def test_main_deletes_when_present(
+        self, mock_am, mock_ga, mock_check_api, mock_read, mock_delete
+    ):
+        """Test main deletes a service that is there"""
+        import plugins.modules.purefa_lds as mod
+
+        module, array = self._wire(mock_am, mock_ga, state="absent")
+        mock_read.return_value = Mock()
+
+        mod.main()
+
+        mock_delete.assert_called_once_with(module, array)
+
+    @patch("plugins.modules.purefa_lds.delete_lds")
+    @patch("plugins.modules.purefa_lds.read_lds")
+    @patch("plugins.modules.purefa_lds.check_api_version")
+    @patch("plugins.modules.purefa_lds.get_array")
+    @patch("plugins.modules.purefa_lds.AnsibleModule")
+    def test_main_absent_and_missing_is_no_change(
+        self, mock_am, mock_ga, mock_check_api, mock_read, mock_delete
+    ):
+        """Test removing something that is not there reports no change"""
+        import plugins.modules.purefa_lds as mod
+
+        module, array = self._wire(mock_am, mock_ga, state="absent")
+        mock_read.return_value = None
+
+        mod.main()
+
+        mock_delete.assert_not_called()
+        module.exit_json.assert_called_once_with(changed=False)


### PR DESCRIPTION
##### SUMMARY

First of the local directory services set identified in the SDK parity review.

Nothing in the collection could manage a local directory service. `purefa_server`
can ask the array to create one as a side effect of creating a file server (its
`create_local_directory_service` option), but the service itself could not be
created, reconfigured, renamed or removed — and neither can the users and groups
inside it, which follow in separate PRs.

`purefa_lds` manages the service and its domain, with the rename shape settled in
#1050 and #1051: a second run of a rename finds nothing under the old name, looks
for the target, and reports no change rather than recreating the source.

##### What the array actually does

Established on a FlashArray running Purity//FA 6.10.6 (REST 2.54) rather than
assumed from the SDK models:

| Behaviour | Consequence for the module |
| --- | --- |
| `domain` is optional on create; the array defaults it to the service name | a play naming only the service stays idempotent — an omitted domain is never treated as a change |
| Two services may share a domain | no uniqueness check needed |
| An unknown name answers **400, not 404** | the existence check treats anything but 200 as absent |
| Every new service gets its own built-in `Administrator`/`Guest` users and `Administrators`/`Guests`/`Backup Operators`/`Audit Operators` groups, none deletable | those names repeat in every service, so the later users and groups modules must scope lookups by service — noted in the module docs |
| Deleting a service deletes every user and group inside it | documented as a `notes:` warning, since it is not recoverable |
| A service in use by a file server cannot be deleted | the array's own message is clear, so it is surfaced as-is |

##### ISSUE TYPE

- New Module Pull Request

##### COMPONENT NAME

purefa_lds

##### ADDITIONAL INFORMATION

Validated on the same array with a playbook that runs every action twice and
asserts the second run is a no-op:

```
TASK [Create must predict in check mode, change once, then no change] ***  ok
TASK [An omitted domain must not be treated as a change] ***  ok
TASK [Domain change must change once then report no change] ***  ok
TASK [Rename must change once then report no change] ***  ok
TASK [A rename onto an existing service must fail] ***  ok
TASK [A rename with nothing to rename must fail and create nothing] ***  ok
TASK [Nothing to remove means no change] ***  ok
TASK [Delete must change once then report no change] ***  ok
TASK [The in-use service must survive with a clear failure] ***  ok

PLAY RECAP
localhost : ok=25  changed=7  unreachable=0  failed=0
```

The array's own `domain` service — the one `_array_server` uses — was left
untouched, and the play removed everything it created.

24 unit tests cover `read_lds` (including the 400-means-absent case),
`create_lds` with and without a domain, `update_lds`, `rename_lds`,
`check_renamed_lds`, `delete_lds`, check mode on each write path, and the `main()`
dispatch including both runs of a rename. Writing them caught a real weakness:
`update_lds` originally called `exit_json` mid-function and relied on it raising
to stop, so it now has a single exit point instead. `ansible-test sanity --local`
passes on both files.

No changelog fragment: antsibull generates the "New Modules" entry from
`short_description`.

Registered in `meta/runtime.yml`, `README.md` and the `import-2.7` line in
`tests/sanity/ignore-2.16.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
