### PR TITLE
feat(purefa_localgroup): Add module to manage local groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ All modules are idempotent with the exception of modules that change or set pass
 - purefa_info - get information regarding the configuration of the Flasharray
 - purefa_inventory - get hardware inventory information from a FlashArray
 - purefa_lds - manage the Local Directory Services of the FlashArray
+- purefa_localgroup - manage local groups on the FlashArray
 - purefa_logging - get audit and session logs from a FlashArray
 - purefa_maintenance - manage FlashArray maintenance windows
 - purefa_messages - list FlashArray alert messages

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -34,6 +34,7 @@ action_groups:
    - purefa_inventory
    - purefa_kmip
    - purefa_lds
+   - purefa_localgroup
    - purefa_logging
    - purefa_maintenance
    - purefa_messages

--- a/plugins/modules/purefa_localgroup.py
+++ b/plugins/modules/purefa_localgroup.py
@@ -1,0 +1,365 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2026, Simon Dodsley (simon@everpuredata.com)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+DOCUMENTATION = r"""
+---
+module: purefa_localgroup
+version_added: '1.45.0'
+short_description: Manage Everpure FlashArray local groups
+description:
+- Create, rename, reconfigure and delete groups inside a local directory
+  service on Everpure FlashArrays.
+- Every group belongs to one local directory service, which is managed by
+  M(everpure.flasharray.purefa_lds). Group names are only unique within a
+  service, so I(local_directory_service) is always required.
+- Each local directory service is created holding its own C(Administrators),
+  C(Guests), C(Backup Operators) and C(Audit Operators) groups. Those are
+  built-in - the array allows neither modifying nor deleting them - so this
+  module reports no change for a I(state=present) task that asks nothing of
+  them, and fails rather than pretending otherwise if a change is requested.
+author:
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@everpuredata.com>
+options:
+  name:
+    description:
+    - Name of the local group
+    type: str
+    required: true
+  local_directory_service:
+    description:
+    - Name of the local directory service the group belongs to.
+    - Required because group names repeat across local directory services.
+    type: str
+    required: true
+  state:
+    description:
+    - Define whether the local group should exist or not.
+    default: present
+    choices: [ absent, present ]
+    type: str
+  gid:
+    description:
+    - Group ID to give the group.
+    - The array assigns one when the group is created without it.
+    - Group IDs only have to be unique within a local directory service.
+    type: int
+  email:
+    description:
+    - Email address to associate with the group.
+    type: str
+  rename:
+    description:
+    - Value to rename the specified local group to
+    - Re-running a rename task reports no change, as long as the group is
+      already known by the new name.
+    type: str
+  context:
+    description:
+    - Name of fleet member on which to perform the operation.
+    - This requires the array receiving the request is a member of a fleet
+      and the context name to be a member of the same fleet.
+    type: str
+    default: ""
+extends_documentation_fragment:
+- everpure.flasharray.everpure.fa
+notes:
+- Supported from Purity//FA 6.8.0 or higher. Local groups themselves go back
+  further, but the parameters that scope a request to one local directory
+  service arrived with the service object itself, and without them a request
+  cannot be aimed reliably once an array holds more than one service.
+- Deleting the local directory service deletes every group in it. See
+  M(everpure.flasharray.purefa_lds).
+"""
+
+EXAMPLES = r"""
+- name: Create local group backup in local directory service foo
+  everpure.flasharray.purefa_localgroup:
+    name: backup
+    local_directory_service: foo
+    gid: 70001
+    email: backup@example.com
+    fa_url: 10.10.10.2
+    api_token: e31060a7-21fc-e277-6240-25983c6c4592
+
+- name: Create local group with an array-assigned GID
+  everpure.flasharray.purefa_localgroup:
+    name: reporting
+    local_directory_service: foo
+    fa_url: 10.10.10.2
+    api_token: e31060a7-21fc-e277-6240-25983c6c4592
+
+- name: Change the email address of local group backup
+  everpure.flasharray.purefa_localgroup:
+    name: backup
+    local_directory_service: foo
+    email: storage@example.com
+    fa_url: 10.10.10.2
+    api_token: e31060a7-21fc-e277-6240-25983c6c4592
+
+- name: Rename local group backup to archive
+  everpure.flasharray.purefa_localgroup:
+    name: backup
+    local_directory_service: foo
+    rename: archive
+    fa_url: 10.10.10.2
+    api_token: e31060a7-21fc-e277-6240-25983c6c4592
+
+- name: Delete local group backup
+  everpure.flasharray.purefa_localgroup:
+    name: backup
+    local_directory_service: foo
+    state: absent
+    fa_url: 10.10.10.2
+    api_token: e31060a7-21fc-e277-6240-25983c6c4592
+"""
+
+RETURN = r"""
+"""
+
+HAS_PURESTORAGE = True
+try:
+    from pypureclient.flasharray import LocalGroupPatch, LocalGroupPost
+except ImportError:
+    HAS_PURESTORAGE = False
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.everpure.flasharray.plugins.module_utils.purefa import (
+    get_array,
+    purefa_argument_spec,
+)
+from ansible_collections.everpure.flasharray.plugins.module_utils.api_helpers import (
+    check_api_version,
+    check_response,
+    delete_with_context,
+    get_with_context,
+    patch_with_context,
+    post_with_context,
+)
+
+# Local groups date from 2.21, but the local_directory_service_names parameter
+# that scopes a request to one service arrived with the service object in 2.44.
+# Without it a request cannot be aimed reliably, because group names repeat in
+# every service, so that is the floor for this module.
+GROUP_API_VERSION = "2.44"
+CONTEXT_VERSION = "2.38"
+
+# The settings this module reconciles, mapped to the field each is read as
+SETTINGS = ("gid", "email")
+
+
+def read_group(module, array, name):
+    """Return the named group from the requested service, or None
+
+    A bare name lookup matches the group of that name in *every* local
+    directory service on the array, so the service has to be part of the
+    query. Anything other than 200 counts as absent - the array answers an
+    unknown name with 400, not 404.
+    """
+    res = get_with_context(
+        array,
+        "get_directory_services_local_groups",
+        CONTEXT_VERSION,
+        module,
+        names=[name],
+        filter="local_directory_service.name='{0}'".format(
+            module.params["local_directory_service"]
+        ),
+    )
+    if res.status_code != 200:
+        return None
+    return next(iter(list(res.items)), None)
+
+
+def _scope(module):
+    """The parameters that aim a write at one local directory service"""
+    return {"local_directory_service_names": [module.params["local_directory_service"]]}
+
+
+def _wanted_changes(module, group):
+    """Return the settings that differ from what the array holds
+
+    An option the play leaves out is never a change, which is what keeps a
+    task that only names the group idempotent.
+    """
+    changes = {}
+    for setting in SETTINGS:
+        wanted = module.params[setting]
+        if wanted is None:
+            continue
+        if wanted != getattr(group, setting, None):
+            changes[setting] = wanted
+    return changes
+
+
+def create_group(module, array):
+    """Create a local group"""
+    if not module.check_mode:
+        res = post_with_context(
+            array,
+            "post_directory_services_local_groups",
+            CONTEXT_VERSION,
+            module,
+            names=[module.params["name"]],
+            local_group=LocalGroupPost(
+                gid=module.params["gid"], email=module.params["email"]
+            ),
+            **_scope(module)
+        )
+        check_response(
+            res,
+            module,
+            "Failed to create local group {0}".format(module.params["name"]),
+        )
+    module.exit_json(changed=True)
+
+
+def update_group(module, array, group):
+    """Bring an existing local group into line with the play"""
+    changes = _wanted_changes(module, group)
+    if changes and getattr(group, "built_in", False):
+        module.fail_json(
+            msg="Local group {0} is built-in and cannot be modified".format(
+                module.params["name"]
+            )
+        )
+    if changes and not module.check_mode:
+        res = patch_with_context(
+            array,
+            "patch_directory_services_local_groups",
+            CONTEXT_VERSION,
+            module,
+            names=[module.params["name"]],
+            local_group=LocalGroupPatch(**changes),
+            **_scope(module)
+        )
+        check_response(
+            res,
+            module,
+            "Failed to update local group {0}".format(module.params["name"]),
+        )
+    module.exit_json(changed=bool(changes))
+
+
+def rename_group(module, array, group):
+    """Rename a local group"""
+    if getattr(group, "built_in", False):
+        module.fail_json(
+            msg="Local group {0} is built-in and cannot be renamed".format(
+                module.params["name"]
+            )
+        )
+    if read_group(module, array, module.params["rename"]):
+        module.fail_json(
+            msg="Target local group {0} already exists".format(module.params["rename"])
+        )
+    if not module.check_mode:
+        res = patch_with_context(
+            array,
+            "patch_directory_services_local_groups",
+            CONTEXT_VERSION,
+            module,
+            names=[module.params["name"]],
+            local_group=LocalGroupPatch(name=module.params["rename"]),
+            **_scope(module)
+        )
+        check_response(
+            res,
+            module,
+            "Failed to rename local group {0}".format(module.params["name"]),
+        )
+    module.exit_json(changed=True)
+
+
+def check_renamed_group(module, array):
+    """Report on a rename whose source group has already gone
+
+    A completed rename leaves nothing under the old name, so a second run of
+    the same task must not create the source again.
+    """
+    if not read_group(module, array, module.params["rename"]):
+        module.fail_json(
+            msg="Local group {0} not found to rename".format(module.params["name"])
+        )
+    module.exit_json(changed=False)
+
+
+def delete_group(module, array, group):
+    """Delete a local group"""
+    if getattr(group, "built_in", False):
+        module.fail_json(
+            msg="Local group {0} is built-in and cannot be deleted".format(
+                module.params["name"]
+            )
+        )
+    if not module.check_mode:
+        res = delete_with_context(
+            array,
+            "delete_directory_services_local_groups",
+            CONTEXT_VERSION,
+            module,
+            names=[module.params["name"]],
+            **_scope(module)
+        )
+        check_response(
+            res,
+            module,
+            "Failed to delete local group {0}".format(module.params["name"]),
+        )
+    module.exit_json(changed=True)
+
+
+def main():
+    argument_spec = purefa_argument_spec()
+    argument_spec.update(
+        dict(
+            state=dict(type="str", default="present", choices=["absent", "present"]),
+            name=dict(type="str", required=True),
+            local_directory_service=dict(type="str", required=True),
+            gid=dict(type="int"),
+            email=dict(type="str"),
+            rename=dict(type="str"),
+            context=dict(type="str", default=""),
+        )
+    )
+
+    module = AnsibleModule(argument_spec, supports_check_mode=True)
+
+    if not HAS_PURESTORAGE:
+        module.fail_json(msg="py-pure-client sdk is required for this module")
+
+    array = get_array(module)
+    check_api_version(array, GROUP_API_VERSION, module, "Local groups")
+
+    state = module.params["state"]
+    group = read_group(module, array, module.params["name"])
+
+    if state == "present" and module.params["rename"]:
+        if group:
+            rename_group(module, array, group)
+        else:
+            check_renamed_group(module, array)
+    elif state == "present" and not group:
+        create_group(module, array)
+    elif state == "present":
+        update_group(module, array, group)
+    elif state == "absent" and group:
+        delete_group(module, array, group)
+
+    module.exit_json(changed=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -84,6 +84,7 @@ plugins/modules/purefa_info.py import-2.7
 plugins/modules/purefa_inventory.py import-2.7
 plugins/modules/purefa_kmip.py import-2.7
 plugins/modules/purefa_lds.py import-2.7
+plugins/modules/purefa_localgroup.py import-2.7
 plugins/modules/purefa_logging.py import-2.7
 plugins/modules/purefa_maintenance.py import-2.7
 plugins/modules/purefa_messages.py import-2.7

--- a/tests/unit/plugins/modules/test_purefa_localgroup.py
+++ b/tests/unit/plugins/modules/test_purefa_localgroup.py
@@ -1,0 +1,502 @@
+# Copyright: (c) 2026, Everpure Ansible Team <pure-ansible-team@everpuredata.com>
+# GNU General Public License v3.0+ (see COPYING.GPLv3 or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for purefa_localgroup module."""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import sys
+from unittest.mock import Mock, MagicMock, patch
+
+import pytest
+
+# Mock external dependencies before importing module
+sys.modules["grp"] = MagicMock()
+sys.modules["pwd"] = MagicMock()
+sys.modules["fcntl"] = MagicMock()
+sys.modules["ansible"] = MagicMock()
+sys.modules["ansible.module_utils"] = MagicMock()
+sys.modules["ansible.module_utils.basic"] = MagicMock()
+sys.modules["pypureclient"] = MagicMock()
+sys.modules["pypureclient.flasharray"] = MagicMock()
+sys.modules["ansible_collections"] = MagicMock()
+sys.modules["ansible_collections.everpure"] = MagicMock()
+sys.modules["ansible_collections.everpure.flasharray"] = MagicMock()
+sys.modules["ansible_collections.everpure.flasharray.plugins"] = MagicMock()
+sys.modules["ansible_collections.everpure.flasharray.plugins.module_utils"] = (
+    MagicMock()
+)
+sys.modules["ansible_collections.everpure.flasharray.plugins.module_utils.purefa"] = (
+    MagicMock()
+)
+sys.modules[
+    "ansible_collections.everpure.flasharray.plugins.module_utils.api_helpers"
+] = MagicMock()
+
+from plugins.modules.purefa_localgroup import (
+    read_group,
+    create_group,
+    update_group,
+    rename_group,
+    check_renamed_group,
+    delete_group,
+    _scope,
+    _wanted_changes,
+)
+
+
+def make_module(**params):
+    """An AnsibleModule stand-in whose fail_json raises, as the real one does"""
+    module = Mock()
+    module.check_mode = False
+    base = {
+        "name": "grp1",
+        "local_directory_service": "lds1",
+        "gid": None,
+        "email": None,
+        "rename": None,
+        "state": "present",
+        "context": "",
+    }
+    base.update(params)
+    module.params = base
+    module.fail_json.side_effect = SystemExit(1)
+    return module
+
+
+def make_group(name="grp1", gid=70001, email="a@example.com", built_in=False):
+    group = Mock()
+    group.name = name
+    group.gid = gid
+    group.email = email
+    group.built_in = built_in
+    return group
+
+
+class TestReadGroup:
+    """Test cases for read_group function"""
+
+    @patch("plugins.modules.purefa_localgroup.get_with_context")
+    def test_read_group_scopes_by_directory_service(self, mock_get):
+        """Test read_group narrows the lookup to one local directory service
+
+        A bare name matches the group of that name in every service on the
+        array, so the service has to be part of the query.
+        """
+        module = make_module()
+        group = make_group()
+        mock_get.return_value = Mock(status_code=200, items=[group])
+
+        assert read_group(module, Mock(), "grp1") is group
+        kwargs = mock_get.call_args[1]
+        assert kwargs["names"] == ["grp1"]
+        assert kwargs["filter"] == "local_directory_service.name='lds1'"
+
+    @patch("plugins.modules.purefa_localgroup.get_with_context")
+    def test_read_group_absent_is_400_not_404(self, mock_get):
+        """Test anything other than 200 counts as absent"""
+        module = make_module()
+        mock_get.return_value = Mock(status_code=400)
+
+        assert read_group(module, Mock(), "nope") is None
+
+    @patch("plugins.modules.purefa_localgroup.get_with_context")
+    def test_read_group_empty_items(self, mock_get):
+        """Test a 200 carrying nothing is absent"""
+        module = make_module()
+        mock_get.return_value = Mock(status_code=200, items=[])
+
+        assert read_group(module, Mock(), "grp1") is None
+
+
+class TestHelpers:
+    """Test cases for the scoping and diff helpers"""
+
+    def test_scope_names_the_directory_service(self):
+        """Test writes are aimed at one local directory service"""
+        module = make_module()
+
+        assert _scope(module) == {"local_directory_service_names": ["lds1"]}
+
+    def test_wanted_changes_ignores_omitted_options(self):
+        """Test an option the play leaves out is never a change"""
+        module = make_module()
+        group = make_group(gid=1, email="x@example.com")
+
+        assert _wanted_changes(module, group) == {}
+
+    def test_wanted_changes_ignores_matching_values(self):
+        """Test a setting that already matches is not a change"""
+        module = make_module(gid=70001, email="a@example.com")
+        group = make_group(gid=70001, email="a@example.com")
+
+        assert _wanted_changes(module, group) == {}
+
+    def test_wanted_changes_reports_differences_only(self):
+        """Test only the differing settings are collected"""
+        module = make_module(gid=70001, email="new@example.com")
+        group = make_group(gid=70001, email="old@example.com")
+
+        assert _wanted_changes(module, group) == {"email": "new@example.com"}
+
+
+class TestCreateGroup:
+    """Test cases for create_group function"""
+
+    def test_create_group_check_mode(self):
+        """Test create_group predicts the change without calling the array"""
+        module = make_module(gid=70001)
+        module.check_mode = True
+
+        create_group(module, Mock())
+
+        module.exit_json.assert_called_once_with(changed=True)
+
+    @patch("plugins.modules.purefa_localgroup.check_response")
+    @patch("plugins.modules.purefa_localgroup.post_with_context")
+    def test_create_group_scoped(self, mock_post, mock_check):
+        """Test create_group posts into the requested service"""
+        module = make_module(gid=70001, email="a@example.com")
+        mock_post.return_value = Mock(status_code=200)
+
+        create_group(module, Mock())
+
+        kwargs = mock_post.call_args[1]
+        assert kwargs["names"] == ["grp1"]
+        assert kwargs["local_directory_service_names"] == ["lds1"]
+        module.exit_json.assert_called_once_with(changed=True)
+
+
+class TestUpdateGroup:
+    """Test cases for update_group function"""
+
+    @patch("plugins.modules.purefa_localgroup.patch_with_context")
+    def test_update_group_nothing_requested(self, mock_patch):
+        """Test naming the group alone reports no change"""
+        module = make_module()
+        update_group(module, Mock(), make_group())
+
+        mock_patch.assert_not_called()
+        module.exit_json.assert_called_once_with(changed=False)
+
+    @patch("plugins.modules.purefa_localgroup.check_response")
+    @patch("plugins.modules.purefa_localgroup.patch_with_context")
+    def test_update_group_changes_email(self, mock_patch, mock_check):
+        """Test a differing setting is patched, scoped to the service"""
+        module = make_module(email="new@example.com")
+        mock_patch.return_value = Mock(status_code=200)
+
+        update_group(module, Mock(), make_group(email="old@example.com"))
+
+        assert mock_patch.call_args[1]["local_directory_service_names"] == ["lds1"]
+        module.exit_json.assert_called_once_with(changed=True)
+
+    @patch("plugins.modules.purefa_localgroup.patch_with_context")
+    def test_update_group_builtin_no_change_allowed(self, mock_patch):
+        """Test a built-in group with nothing asked of it is not an error"""
+        module = make_module()
+
+        update_group(module, Mock(), make_group(built_in=True))
+
+        mock_patch.assert_not_called()
+        module.exit_json.assert_called_once_with(changed=False)
+        module.fail_json.assert_not_called()
+
+    @patch("plugins.modules.purefa_localgroup.patch_with_context")
+    def test_update_group_builtin_change_fails(self, mock_patch):
+        """Test changing a built-in group fails before the array is called"""
+        module = make_module(email="nope@example.com")
+
+        with pytest.raises(SystemExit):
+            update_group(
+                module, Mock(), make_group(email="a@example.com", built_in=True)
+            )
+
+        assert "built-in" in module.fail_json.call_args[1]["msg"]
+        mock_patch.assert_not_called()
+
+    @patch("plugins.modules.purefa_localgroup.patch_with_context")
+    def test_update_group_check_mode(self, mock_patch):
+        """Test update_group predicts a change without making it"""
+        module = make_module(gid=70009)
+        module.check_mode = True
+
+        update_group(module, Mock(), make_group(gid=70001))
+
+        mock_patch.assert_not_called()
+        module.exit_json.assert_called_once_with(changed=True)
+
+
+class TestRenameGroup:
+    """Test cases for rename_group function"""
+
+    @patch("plugins.modules.purefa_localgroup.check_response")
+    @patch("plugins.modules.purefa_localgroup.patch_with_context")
+    @patch("plugins.modules.purefa_localgroup.read_group")
+    def test_rename_group_success(self, mock_read, mock_patch, mock_check):
+        """Test rename_group patches the new name when it is free"""
+        module = make_module(rename="grp2")
+        mock_read.return_value = None
+        mock_patch.return_value = Mock(status_code=200)
+
+        rename_group(module, Mock(), make_group())
+
+        assert mock_patch.call_args[1]["local_directory_service_names"] == ["lds1"]
+        module.exit_json.assert_called_once_with(changed=True)
+
+    @patch("plugins.modules.purefa_localgroup.patch_with_context")
+    @patch("plugins.modules.purefa_localgroup.read_group")
+    def test_rename_group_target_exists_fails(self, mock_read, mock_patch):
+        """Test renaming onto an existing group in the same service fails"""
+        module = make_module(rename="grp2")
+        mock_read.return_value = make_group(name="grp2")
+
+        with pytest.raises(SystemExit):
+            rename_group(module, Mock(), make_group())
+
+        assert "already exists" in module.fail_json.call_args[1]["msg"]
+        mock_patch.assert_not_called()
+
+    @patch("plugins.modules.purefa_localgroup.patch_with_context")
+    @patch("plugins.modules.purefa_localgroup.read_group")
+    def test_rename_group_builtin_fails(self, mock_read, mock_patch):
+        """Test a built-in group cannot be renamed"""
+        module = make_module(rename="grp2")
+
+        with pytest.raises(SystemExit):
+            rename_group(module, Mock(), make_group(built_in=True))
+
+        assert "built-in" in module.fail_json.call_args[1]["msg"]
+        mock_patch.assert_not_called()
+        mock_read.assert_not_called()
+
+
+class TestCheckRenamedGroup:
+    """Test cases for check_renamed_group, the second run of a rename"""
+
+    @patch("plugins.modules.purefa_localgroup.read_group")
+    def test_check_renamed_group_already_renamed(self, mock_read):
+        """Test no change is reported once the target is there"""
+        module = make_module(rename="grp2")
+        mock_read.return_value = make_group(name="grp2")
+
+        check_renamed_group(module, Mock())
+
+        module.exit_json.assert_called_once_with(changed=False)
+        module.fail_json.assert_not_called()
+
+    @patch("plugins.modules.purefa_localgroup.read_group")
+    def test_check_renamed_group_neither_exists_fails(self, mock_read):
+        """Test a rename with nothing to rename fails instead of creating"""
+        module = make_module(rename="grp2")
+        mock_read.return_value = None
+
+        with pytest.raises(SystemExit):
+            check_renamed_group(module, Mock())
+
+        assert "not found to rename" in module.fail_json.call_args[1]["msg"]
+        module.exit_json.assert_not_called()
+
+
+class TestDeleteGroup:
+    """Test cases for delete_group function"""
+
+    def test_delete_group_check_mode(self):
+        """Test delete_group predicts the change without calling the array"""
+        module = make_module(state="absent")
+        module.check_mode = True
+
+        delete_group(module, Mock(), make_group())
+
+        module.exit_json.assert_called_once_with(changed=True)
+
+    @patch("plugins.modules.purefa_localgroup.check_response")
+    @patch("plugins.modules.purefa_localgroup.delete_with_context")
+    def test_delete_group_scoped(self, mock_delete, mock_check):
+        """Test delete_group only targets the requested service"""
+        module = make_module(state="absent")
+        mock_delete.return_value = Mock(status_code=200)
+
+        delete_group(module, Mock(), make_group())
+
+        kwargs = mock_delete.call_args[1]
+        assert kwargs["names"] == ["grp1"]
+        assert kwargs["local_directory_service_names"] == ["lds1"]
+        module.exit_json.assert_called_once_with(changed=True)
+
+    @patch("plugins.modules.purefa_localgroup.delete_with_context")
+    def test_delete_group_builtin_fails(self, mock_delete):
+        """Test a built-in group cannot be deleted"""
+        module = make_module(state="absent")
+
+        with pytest.raises(SystemExit):
+            delete_group(module, Mock(), make_group(built_in=True))
+
+        assert "built-in" in module.fail_json.call_args[1]["msg"]
+        mock_delete.assert_not_called()
+
+
+class TestMain:
+    """Test cases for the main dispatch"""
+
+    @patch("plugins.modules.purefa_localgroup.get_array")
+    @patch("plugins.modules.purefa_localgroup.AnsibleModule")
+    def test_main_no_purestorage_sdk(self, mock_am, mock_ga):
+        """Test main fails when py-pure-client is missing"""
+        import plugins.modules.purefa_localgroup as mod
+
+        original = mod.HAS_PURESTORAGE
+        mod.HAS_PURESTORAGE = False
+        module = make_module()
+        mock_am.return_value = module
+        try:
+            with pytest.raises(SystemExit):
+                mod.main()
+            assert "sdk is required" in module.fail_json.call_args[1]["msg"]
+        finally:
+            mod.HAS_PURESTORAGE = original
+
+    @staticmethod
+    def _wire(mock_am, mock_ga, **params):
+        module = make_module(**params)
+        mock_am.return_value = module
+        array = Mock()
+        mock_ga.return_value = array
+        return module, array
+
+    @patch("plugins.modules.purefa_localgroup.create_group")
+    @patch("plugins.modules.purefa_localgroup.read_group")
+    @patch("plugins.modules.purefa_localgroup.check_api_version")
+    @patch("plugins.modules.purefa_localgroup.get_array")
+    @patch("plugins.modules.purefa_localgroup.AnsibleModule")
+    def test_main_creates_when_absent(
+        self, mock_am, mock_ga, mock_api, mock_read, mock_create
+    ):
+        """Test main creates a group the service does not hold"""
+        import plugins.modules.purefa_localgroup as mod
+
+        module, array = self._wire(mock_am, mock_ga)
+        mock_read.return_value = None
+
+        mod.main()
+
+        mock_create.assert_called_once_with(module, array)
+        mock_api.assert_called_once()
+
+    @patch("plugins.modules.purefa_localgroup.update_group")
+    @patch("plugins.modules.purefa_localgroup.read_group")
+    @patch("plugins.modules.purefa_localgroup.check_api_version")
+    @patch("plugins.modules.purefa_localgroup.get_array")
+    @patch("plugins.modules.purefa_localgroup.AnsibleModule")
+    def test_main_updates_when_present(
+        self, mock_am, mock_ga, mock_api, mock_read, mock_update
+    ):
+        """Test main reconciles a group that is already there"""
+        import plugins.modules.purefa_localgroup as mod
+
+        module, array = self._wire(mock_am, mock_ga, email="a@example.com")
+        group = make_group()
+        mock_read.return_value = group
+
+        mod.main()
+
+        mock_update.assert_called_once_with(module, array, group)
+
+    @patch("plugins.modules.purefa_localgroup.check_renamed_group")
+    @patch("plugins.modules.purefa_localgroup.create_group")
+    @patch("plugins.modules.purefa_localgroup.rename_group")
+    @patch("plugins.modules.purefa_localgroup.read_group")
+    @patch("plugins.modules.purefa_localgroup.check_api_version")
+    @patch("plugins.modules.purefa_localgroup.get_array")
+    @patch("plugins.modules.purefa_localgroup.AnsibleModule")
+    def test_main_rename_first_run(
+        self,
+        mock_am,
+        mock_ga,
+        mock_api,
+        mock_read,
+        mock_rename,
+        mock_create,
+        mock_checked,
+    ):
+        """First run: the source is there, so the rename happens"""
+        import plugins.modules.purefa_localgroup as mod
+
+        module, array = self._wire(mock_am, mock_ga, rename="grp2")
+        group = make_group()
+        mock_read.return_value = group
+
+        mod.main()
+
+        mock_rename.assert_called_once_with(module, array, group)
+        mock_create.assert_not_called()
+        mock_checked.assert_not_called()
+
+    @patch("plugins.modules.purefa_localgroup.check_renamed_group")
+    @patch("plugins.modules.purefa_localgroup.create_group")
+    @patch("plugins.modules.purefa_localgroup.rename_group")
+    @patch("plugins.modules.purefa_localgroup.read_group")
+    @patch("plugins.modules.purefa_localgroup.check_api_version")
+    @patch("plugins.modules.purefa_localgroup.get_array")
+    @patch("plugins.modules.purefa_localgroup.AnsibleModule")
+    def test_main_rename_second_run_does_not_create(
+        self,
+        mock_am,
+        mock_ga,
+        mock_api,
+        mock_read,
+        mock_rename,
+        mock_create,
+        mock_checked,
+    ):
+        """Second run: the source has gone, and must not be created again"""
+        import plugins.modules.purefa_localgroup as mod
+
+        module, array = self._wire(mock_am, mock_ga, rename="grp2")
+        mock_read.return_value = None
+
+        mod.main()
+
+        mock_checked.assert_called_once_with(module, array)
+        mock_create.assert_not_called()
+        mock_rename.assert_not_called()
+
+    @patch("plugins.modules.purefa_localgroup.delete_group")
+    @patch("plugins.modules.purefa_localgroup.read_group")
+    @patch("plugins.modules.purefa_localgroup.check_api_version")
+    @patch("plugins.modules.purefa_localgroup.get_array")
+    @patch("plugins.modules.purefa_localgroup.AnsibleModule")
+    def test_main_deletes_when_present(
+        self, mock_am, mock_ga, mock_api, mock_read, mock_delete
+    ):
+        """Test main deletes a group that is there"""
+        import plugins.modules.purefa_localgroup as mod
+
+        module, array = self._wire(mock_am, mock_ga, state="absent")
+        group = make_group()
+        mock_read.return_value = group
+
+        mod.main()
+
+        mock_delete.assert_called_once_with(module, array, group)
+
+    @patch("plugins.modules.purefa_localgroup.delete_group")
+    @patch("plugins.modules.purefa_localgroup.read_group")
+    @patch("plugins.modules.purefa_localgroup.check_api_version")
+    @patch("plugins.modules.purefa_localgroup.get_array")
+    @patch("plugins.modules.purefa_localgroup.AnsibleModule")
+    def test_main_absent_and_missing_is_no_change(
+        self, mock_am, mock_ga, mock_api, mock_read, mock_delete
+    ):
+        """Test removing something that is not there reports no change"""
+        import plugins.modules.purefa_localgroup as mod
+
+        module, array = self._wire(mock_am, mock_ga, state="absent")
+        mock_read.return_value = None
+
+        mod.main()
+
+        mock_delete.assert_not_called()
+        module.exit_json.assert_called_once_with(changed=False)


### PR DESCRIPTION
##### SUMMARY

Second of the local directory services set, following #1052. Groups inside a
local directory service could not be managed at all.

The option that shapes this module is `local_directory_service`, and it is
**required**. Group names are only unique within a service, and creating a
service gives it its own `Administrators`, `Guests`, `Backup Operators` and
`Audit Operators` groups — so on an array with three services, a bare lookup for
`Guests` matches three different groups. Every read therefore carries a filter on
`local_directory_service.name`, and every write carries
`local_directory_service_names`.

##### Why REST 2.44 and not 2.21

The group endpoints themselves date from 2.21, but the parameters that aim a
request at one service (`local_directory_service_names`) arrived at **2.44**,
alongside the service object. I checked this version by version through the SDK
rather than assuming. Without those parameters a request cannot be aimed
reliably once an array holds more than one service — and on a pre-2.44 array the
containing service can neither be seen nor managed, so reaching further back
buys nothing but risk.

##### What the array actually does

Established on a FlashArray running Purity//FA 6.10.6 (REST 2.54):

| Behaviour | Consequence for the module |
| --- | --- |
| `names=` and `filter=` combine on a GET | this is what makes an unambiguous read possible — `names` alone returned the group from *every* service |
| `gid`, `email` and `name` are all mutable on a user-created group | all three are reconcilable options |
| Built-in groups refuse **modification** (`Modifying built-in group is not allowed.`) as well as deletion (`Cannot delete built-in group.`) | the module checks `built_in` itself, so the failure names the group and what was refused |
| A duplicate name within one service is refused; the same name in another service is fine | rename checks for a clash only within the target service |
| GIDs only have to be unique within a service | documented, and not validated across services |

A `state: present` task that asks nothing of a built-in group reports **no
change** rather than failing — ensuring one exists is a reasonable thing to
write. Only a requested change is refused.

##### ISSUE TYPE

- New Module Pull Request

##### COMPONENT NAME

purefa_localgroup

##### ADDITIONAL INFORMATION

Validated on the same array with a playbook that runs every action twice and
asserts the second run is a no-op. The scoping is tested directly, because that
is where this module could silently act on the wrong object:

```
TASK [Create must predict, change once, then report no change] ***  ok
TASK [An options-free present task is idempotent] ***  ok
TASK [The same name in two services must be two groups, both idempotent] ***  ok
TASK [A scoped delete must not reach into the other service] ***  ok
TASK [Settings change must change once then report no change] ***  ok
TASK [Rename must change once then report no change] ***  ok
TASK [A rename with nothing to rename must fail] ***  ok
TASK [Built-ins must be readable, but refuse every change] ***  ok
TASK [Delete must change once then report no change] ***  ok

PLAY RECAP
localhost : ok=31  changed=10  unreachable=0  failed=0
```

The play built its own two local directory services and removed them at the end,
so the array's own `domain` service — the one `_array_server` depends on — was
never touched, and the array finished byte-identical to the baseline taken first.

29 unit tests cover the scoped read (including that anything but 200 means
absent, since the array answers an unknown name with 400), the diff helper that
keeps omitted options from counting as changes, create/update/rename/delete,
check mode on each write path, all three built-in refusals, and the `main()`
dispatch including both runs of a rename.

`ansible-test sanity --local` passes. No f-strings, so no `compile-2.7` ignore
entry is needed — that test only runs where a python2.7 interpreter exists, which
is how it slipped past local testing in #1052.

No changelog fragment: antsibull generates the "New Modules" entry from
`short_description`.

`purefa_localuser` follows, with the mandatory `password` and `primary_group` on
create and the asymmetric membership endpoints for secondary groups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
