### PR TITLE
feat(purefa_localuser): Add module to manage local users

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ All modules are idempotent with the exception of modules that change or set pass
 - purefa_info - get information regarding the configuration of the Flasharray
 - purefa_inventory - get hardware inventory information from a FlashArray
 - purefa_lds - manage the Local Directory Services of the FlashArray
+- purefa_localgroup - manage local groups on the FlashArray
 - purefa_logging - get audit and session logs from a FlashArray
 - purefa_maintenance - manage FlashArray maintenance windows
 - purefa_messages - list FlashArray alert messages

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ All modules are idempotent with the exception of modules that change or set pass
 - purefa_inventory - get hardware inventory information from a FlashArray
 - purefa_lds - manage the Local Directory Services of the FlashArray
 - purefa_localgroup - manage local groups on the FlashArray
+- purefa_localuser - manage local users on the FlashArray
 - purefa_logging - get audit and session logs from a FlashArray
 - purefa_maintenance - manage FlashArray maintenance windows
 - purefa_messages - list FlashArray alert messages

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -35,6 +35,7 @@ action_groups:
    - purefa_kmip
    - purefa_lds
    - purefa_localgroup
+   - purefa_localuser
    - purefa_logging
    - purefa_maintenance
    - purefa_messages

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -34,6 +34,7 @@ action_groups:
    - purefa_inventory
    - purefa_kmip
    - purefa_lds
+   - purefa_localgroup
    - purefa_logging
    - purefa_maintenance
    - purefa_messages

--- a/plugins/modules/purefa_localgroup.py
+++ b/plugins/modules/purefa_localgroup.py
@@ -1,0 +1,365 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2026, Simon Dodsley (simon@everpuredata.com)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+DOCUMENTATION = r"""
+---
+module: purefa_localgroup
+version_added: '1.45.0'
+short_description: Manage Everpure FlashArray local groups
+description:
+- Create, rename, reconfigure and delete groups inside a local directory
+  service on Everpure FlashArrays.
+- Every group belongs to one local directory service, which is managed by
+  M(everpure.flasharray.purefa_lds). Group names are only unique within a
+  service, so I(local_directory_service) is always required.
+- Each local directory service is created holding its own C(Administrators),
+  C(Guests), C(Backup Operators) and C(Audit Operators) groups. Those are
+  built-in - the array allows neither modifying nor deleting them - so this
+  module reports no change for a I(state=present) task that asks nothing of
+  them, and fails rather than pretending otherwise if a change is requested.
+author:
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@everpuredata.com>
+options:
+  name:
+    description:
+    - Name of the local group
+    type: str
+    required: true
+  local_directory_service:
+    description:
+    - Name of the local directory service the group belongs to.
+    - Required because group names repeat across local directory services.
+    type: str
+    required: true
+  state:
+    description:
+    - Define whether the local group should exist or not.
+    default: present
+    choices: [ absent, present ]
+    type: str
+  gid:
+    description:
+    - Group ID to give the group.
+    - The array assigns one when the group is created without it.
+    - Group IDs only have to be unique within a local directory service.
+    type: int
+  email:
+    description:
+    - Email address to associate with the group.
+    type: str
+  rename:
+    description:
+    - Value to rename the specified local group to
+    - Re-running a rename task reports no change, as long as the group is
+      already known by the new name.
+    type: str
+  context:
+    description:
+    - Name of fleet member on which to perform the operation.
+    - This requires the array receiving the request is a member of a fleet
+      and the context name to be a member of the same fleet.
+    type: str
+    default: ""
+extends_documentation_fragment:
+- everpure.flasharray.everpure.fa
+notes:
+- Supported from Purity//FA 6.8.0 or higher. Local groups themselves go back
+  further, but the parameters that scope a request to one local directory
+  service arrived with the service object itself, and without them a request
+  cannot be aimed reliably once an array holds more than one service.
+- Deleting the local directory service deletes every group in it. See
+  M(everpure.flasharray.purefa_lds).
+"""
+
+EXAMPLES = r"""
+- name: Create local group backup in local directory service foo
+  everpure.flasharray.purefa_localgroup:
+    name: backup
+    local_directory_service: foo
+    gid: 70001
+    email: backup@example.com
+    fa_url: 10.10.10.2
+    api_token: e31060a7-21fc-e277-6240-25983c6c4592
+
+- name: Create local group with an array-assigned GID
+  everpure.flasharray.purefa_localgroup:
+    name: reporting
+    local_directory_service: foo
+    fa_url: 10.10.10.2
+    api_token: e31060a7-21fc-e277-6240-25983c6c4592
+
+- name: Change the email address of local group backup
+  everpure.flasharray.purefa_localgroup:
+    name: backup
+    local_directory_service: foo
+    email: storage@example.com
+    fa_url: 10.10.10.2
+    api_token: e31060a7-21fc-e277-6240-25983c6c4592
+
+- name: Rename local group backup to archive
+  everpure.flasharray.purefa_localgroup:
+    name: backup
+    local_directory_service: foo
+    rename: archive
+    fa_url: 10.10.10.2
+    api_token: e31060a7-21fc-e277-6240-25983c6c4592
+
+- name: Delete local group backup
+  everpure.flasharray.purefa_localgroup:
+    name: backup
+    local_directory_service: foo
+    state: absent
+    fa_url: 10.10.10.2
+    api_token: e31060a7-21fc-e277-6240-25983c6c4592
+"""
+
+RETURN = r"""
+"""
+
+HAS_PURESTORAGE = True
+try:
+    from pypureclient.flasharray import LocalGroupPatch, LocalGroupPost
+except ImportError:
+    HAS_PURESTORAGE = False
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.everpure.flasharray.plugins.module_utils.purefa import (
+    get_array,
+    purefa_argument_spec,
+)
+from ansible_collections.everpure.flasharray.plugins.module_utils.api_helpers import (
+    check_api_version,
+    check_response,
+    delete_with_context,
+    get_with_context,
+    patch_with_context,
+    post_with_context,
+)
+
+# Local groups date from 2.21, but the local_directory_service_names parameter
+# that scopes a request to one service arrived with the service object in 2.44.
+# Without it a request cannot be aimed reliably, because group names repeat in
+# every service, so that is the floor for this module.
+GROUP_API_VERSION = "2.44"
+CONTEXT_VERSION = "2.38"
+
+# The settings this module reconciles, mapped to the field each is read as
+SETTINGS = ("gid", "email")
+
+
+def read_group(module, array, name):
+    """Return the named group from the requested service, or None
+
+    A bare name lookup matches the group of that name in *every* local
+    directory service on the array, so the service has to be part of the
+    query. Anything other than 200 counts as absent - the array answers an
+    unknown name with 400, not 404.
+    """
+    res = get_with_context(
+        array,
+        "get_directory_services_local_groups",
+        CONTEXT_VERSION,
+        module,
+        names=[name],
+        filter="local_directory_service.name='{0}'".format(
+            module.params["local_directory_service"]
+        ),
+    )
+    if res.status_code != 200:
+        return None
+    return next(iter(list(res.items)), None)
+
+
+def _scope(module):
+    """The parameters that aim a write at one local directory service"""
+    return {"local_directory_service_names": [module.params["local_directory_service"]]}
+
+
+def _wanted_changes(module, group):
+    """Return the settings that differ from what the array holds
+
+    An option the play leaves out is never a change, which is what keeps a
+    task that only names the group idempotent.
+    """
+    changes = {}
+    for setting in SETTINGS:
+        wanted = module.params[setting]
+        if wanted is None:
+            continue
+        if wanted != getattr(group, setting, None):
+            changes[setting] = wanted
+    return changes
+
+
+def create_group(module, array):
+    """Create a local group"""
+    if not module.check_mode:
+        res = post_with_context(
+            array,
+            "post_directory_services_local_groups",
+            CONTEXT_VERSION,
+            module,
+            names=[module.params["name"]],
+            local_group=LocalGroupPost(
+                gid=module.params["gid"], email=module.params["email"]
+            ),
+            **_scope(module)
+        )
+        check_response(
+            res,
+            module,
+            "Failed to create local group {0}".format(module.params["name"]),
+        )
+    module.exit_json(changed=True)
+
+
+def update_group(module, array, group):
+    """Bring an existing local group into line with the play"""
+    changes = _wanted_changes(module, group)
+    if changes and getattr(group, "built_in", False):
+        module.fail_json(
+            msg="Local group {0} is built-in and cannot be modified".format(
+                module.params["name"]
+            )
+        )
+    if changes and not module.check_mode:
+        res = patch_with_context(
+            array,
+            "patch_directory_services_local_groups",
+            CONTEXT_VERSION,
+            module,
+            names=[module.params["name"]],
+            local_group=LocalGroupPatch(**changes),
+            **_scope(module)
+        )
+        check_response(
+            res,
+            module,
+            "Failed to update local group {0}".format(module.params["name"]),
+        )
+    module.exit_json(changed=bool(changes))
+
+
+def rename_group(module, array, group):
+    """Rename a local group"""
+    if getattr(group, "built_in", False):
+        module.fail_json(
+            msg="Local group {0} is built-in and cannot be renamed".format(
+                module.params["name"]
+            )
+        )
+    if read_group(module, array, module.params["rename"]):
+        module.fail_json(
+            msg="Target local group {0} already exists".format(module.params["rename"])
+        )
+    if not module.check_mode:
+        res = patch_with_context(
+            array,
+            "patch_directory_services_local_groups",
+            CONTEXT_VERSION,
+            module,
+            names=[module.params["name"]],
+            local_group=LocalGroupPatch(name=module.params["rename"]),
+            **_scope(module)
+        )
+        check_response(
+            res,
+            module,
+            "Failed to rename local group {0}".format(module.params["name"]),
+        )
+    module.exit_json(changed=True)
+
+
+def check_renamed_group(module, array):
+    """Report on a rename whose source group has already gone
+
+    A completed rename leaves nothing under the old name, so a second run of
+    the same task must not create the source again.
+    """
+    if not read_group(module, array, module.params["rename"]):
+        module.fail_json(
+            msg="Local group {0} not found to rename".format(module.params["name"])
+        )
+    module.exit_json(changed=False)
+
+
+def delete_group(module, array, group):
+    """Delete a local group"""
+    if getattr(group, "built_in", False):
+        module.fail_json(
+            msg="Local group {0} is built-in and cannot be deleted".format(
+                module.params["name"]
+            )
+        )
+    if not module.check_mode:
+        res = delete_with_context(
+            array,
+            "delete_directory_services_local_groups",
+            CONTEXT_VERSION,
+            module,
+            names=[module.params["name"]],
+            **_scope(module)
+        )
+        check_response(
+            res,
+            module,
+            "Failed to delete local group {0}".format(module.params["name"]),
+        )
+    module.exit_json(changed=True)
+
+
+def main():
+    argument_spec = purefa_argument_spec()
+    argument_spec.update(
+        dict(
+            state=dict(type="str", default="present", choices=["absent", "present"]),
+            name=dict(type="str", required=True),
+            local_directory_service=dict(type="str", required=True),
+            gid=dict(type="int"),
+            email=dict(type="str"),
+            rename=dict(type="str"),
+            context=dict(type="str", default=""),
+        )
+    )
+
+    module = AnsibleModule(argument_spec, supports_check_mode=True)
+
+    if not HAS_PURESTORAGE:
+        module.fail_json(msg="py-pure-client sdk is required for this module")
+
+    array = get_array(module)
+    check_api_version(array, GROUP_API_VERSION, module, "Local groups")
+
+    state = module.params["state"]
+    group = read_group(module, array, module.params["name"])
+
+    if state == "present" and module.params["rename"]:
+        if group:
+            rename_group(module, array, group)
+        else:
+            check_renamed_group(module, array)
+    elif state == "present" and not group:
+        create_group(module, array)
+    elif state == "present":
+        update_group(module, array, group)
+    elif state == "absent" and group:
+        delete_group(module, array, group)
+
+    module.exit_json(changed=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/purefa_localuser.py
+++ b/plugins/modules/purefa_localuser.py
@@ -1,0 +1,577 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2026, Simon Dodsley (simon@everpuredata.com)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+DOCUMENTATION = r"""
+---
+module: purefa_localuser
+version_added: '1.45.0'
+short_description: Manage Everpure FlashArray local users
+description:
+- Create, rename, reconfigure and delete users inside a local directory service
+  on Everpure FlashArrays, and manage the groups they belong to.
+- Every user belongs to one local directory service, which is managed by
+  M(everpure.flasharray.purefa_lds). User names are only unique within a
+  service, so I(local_directory_service) is always required. The groups a user
+  joins are managed by M(everpure.flasharray.purefa_localgroup).
+- Each local directory service is created holding its own C(Administrator) and
+  C(Guest) users. Those are built-in - the array allows them to be modified,
+  which is how a password is set on a new service's C(Administrator), but not
+  deleted.
+author:
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@everpuredata.com>
+options:
+  name:
+    description:
+    - Name of the local user
+    type: str
+    required: true
+  local_directory_service:
+    description:
+    - Name of the local directory service the user belongs to.
+    - Required because user names repeat across local directory services.
+    type: str
+    required: true
+  state:
+    description:
+    - Define whether the local user should exist or not.
+    default: present
+    choices: [ absent, present ]
+    type: str
+  password:
+    description:
+    - Password for the local user.
+    - Required when creating a user.
+    - Whether an existing user's password is reset is controlled by
+      I(update_password).
+    type: str
+  update_password:
+    description:
+    - C(on_create) only sets the password when the user is created, which keeps
+      a task that carries a password idempotent.
+    - C(always) resets the password on every run. The array does not allow a
+      password to be read back, so there is nothing to compare against and such
+      a task always reports a change.
+    default: on_create
+    choices: [ always, on_create ]
+    type: str
+  primary_group:
+    description:
+    - Name of the group to make the user's primary group.
+    - Required when creating a user, and the group has to exist already.
+    - A user must belong to a group before it can become their primary group.
+      This module joins the group first when it has to.
+    type: str
+  groups:
+    description:
+    - The groups the user belongs to besides I(primary_group).
+    - This is declarative - groups not in the list are left, and the user is
+      removed from any others. Omit it to leave the user's groups alone.
+    - The primary group is always a membership and is ignored if listed here.
+    type: list
+    elements: str
+  uid:
+    description:
+    - User ID to give the user.
+    - The array assigns one when the user is created without it.
+    - User IDs only have to be unique within a local directory service.
+    type: int
+  email:
+    description:
+    - Email address to associate with the user.
+    type: str
+  enabled:
+    description:
+    - Whether the user is allowed to authenticate.
+    type: bool
+  rename:
+    description:
+    - Value to rename the specified local user to
+    - Re-running a rename task reports no change, as long as the user is
+      already known by the new name.
+    type: str
+  context:
+    description:
+    - Name of fleet member on which to perform the operation.
+    - This requires the array receiving the request is a member of a fleet
+      and the context name to be a member of the same fleet.
+    type: str
+    default: ""
+extends_documentation_fragment:
+- everpure.flasharray.everpure.fa
+notes:
+- Supported from Purity//FA 6.8.0 or higher. Local users themselves go back
+  further, but the parameters that scope a request to one local directory
+  service arrived with the service object itself, and without them a request
+  cannot be aimed reliably once an array holds more than one service.
+- The array limits a local user name to 20 characters. Alphanumeric US
+  ASCII, spaces and symbols are allowed, but not control characters, and not
+  the symbols C(/), C(\\), C([), C(]), C(:), C(;), C(|), C(=), C(,), C(+),
+  C(*), C(?), C(<), C(>) or C(@). A name may not be digits alone, and may
+  neither start nor end with a dot or a space.
+- Creating a user requires both I(password) and I(primary_group). The array
+  refuses either on its own.
+- Deleting the local directory service deletes every user in it. See
+  M(everpure.flasharray.purefa_lds).
+"""
+
+EXAMPLES = r"""
+- name: Create local user fred in local directory service foo
+  everpure.flasharray.purefa_localuser:
+    name: fred
+    local_directory_service: foo
+    password: "{{ fred_password }}"
+    primary_group: users
+    uid: 71000
+    email: fred@example.com
+    fa_url: 10.10.10.2
+    api_token: e31060a7-21fc-e277-6240-25983c6c4592
+
+- name: Create local user fred in two extra groups
+  everpure.flasharray.purefa_localuser:
+    name: fred
+    local_directory_service: foo
+    password: "{{ fred_password }}"
+    primary_group: users
+    groups:
+    - backup
+    - reporting
+    fa_url: 10.10.10.2
+    api_token: e31060a7-21fc-e277-6240-25983c6c4592
+
+- name: Remove fred from every group except his primary one
+  everpure.flasharray.purefa_localuser:
+    name: fred
+    local_directory_service: foo
+    groups: []
+    fa_url: 10.10.10.2
+    api_token: e31060a7-21fc-e277-6240-25983c6c4592
+
+- name: Set the password on a new service's built-in Administrator
+  everpure.flasharray.purefa_localuser:
+    name: Administrator
+    local_directory_service: foo
+    password: "{{ admin_password }}"
+    update_password: always
+    fa_url: 10.10.10.2
+    api_token: e31060a7-21fc-e277-6240-25983c6c4592
+
+- name: Disable local user fred
+  everpure.flasharray.purefa_localuser:
+    name: fred
+    local_directory_service: foo
+    enabled: false
+    fa_url: 10.10.10.2
+    api_token: e31060a7-21fc-e277-6240-25983c6c4592
+
+- name: Delete local user fred
+  everpure.flasharray.purefa_localuser:
+    name: fred
+    local_directory_service: foo
+    state: absent
+    fa_url: 10.10.10.2
+    api_token: e31060a7-21fc-e277-6240-25983c6c4592
+"""
+
+RETURN = r"""
+"""
+
+HAS_PURESTORAGE = True
+try:
+    from pypureclient.flasharray import (
+        LocalUserMembershipPost,
+        LocalUserPatch,
+        LocalUserPost,
+        LocalusermembershippostGroups,
+        Reference,
+    )
+except ImportError:
+    HAS_PURESTORAGE = False
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.everpure.flasharray.plugins.module_utils.purefa import (
+    get_array,
+    purefa_argument_spec,
+)
+from ansible_collections.everpure.flasharray.plugins.module_utils.api_helpers import (
+    check_api_version,
+    check_response,
+    delete_with_context,
+    get_with_context,
+    patch_with_context,
+    post_with_context,
+)
+
+# Local users date from 2.21, but the local_directory_service_names parameter
+# that scopes a request to one service arrived with the service object in 2.44.
+# User names repeat in every service, so that is the floor for this module.
+USER_API_VERSION = "2.44"
+CONTEXT_VERSION = "2.38"
+
+# The plain settings this module reconciles by comparing what the array holds
+SETTINGS = ("uid", "email", "enabled")
+
+
+def _scope(module):
+    """The parameters that aim a write at one local directory service"""
+    return {"local_directory_service_names": [module.params["local_directory_service"]]}
+
+
+def _service_filter(module):
+    """A filter clause restricting a read to one local directory service"""
+    return "local_directory_service.name='{0}'".format(
+        module.params["local_directory_service"]
+    )
+
+
+def read_user(module, array, name):
+    """Return the named user from the requested service, or None
+
+    A bare name lookup matches the user of that name in every local directory
+    service on the array, so the service has to be part of the query. Anything
+    other than 200 counts as absent - the array answers an unknown name with
+    400, not 404.
+    """
+    res = get_with_context(
+        array,
+        "get_directory_services_local_users",
+        CONTEXT_VERSION,
+        module,
+        names=[name],
+        filter=_service_filter(module),
+    )
+    if res.status_code != 200:
+        return None
+    return next(iter(list(res.items)), None)
+
+
+def read_memberships(module, array, name):
+    """Return {group name: is primary} for the named user"""
+    res = get_with_context(
+        array,
+        "get_directory_services_local_users_members",
+        CONTEXT_VERSION,
+        module,
+        filter="member.name='{0}' and {1}".format(name, _service_filter(module)),
+    )
+    if res.status_code != 200:
+        return {}
+    found = {}
+    for member in list(res.items):
+        group = getattr(getattr(member, "group", None), "name", None)
+        if group:
+            found[group] = bool(getattr(member, "is_primary_group", False))
+    return found
+
+
+def _primary_group_name(user):
+    """The name of a user's primary group, or None"""
+    return getattr(getattr(user, "primary_group", None), "name", None)
+
+
+def _plain_changes(module, user):
+    """Return the plain settings that differ from what the array holds
+
+    An option the play leaves out is never a change, which keeps a task that
+    only names the user idempotent.
+    """
+    changes = {}
+    for setting in SETTINGS:
+        wanted = module.params[setting]
+        if wanted is None:
+            continue
+        if wanted != getattr(user, setting, None):
+            changes[setting] = wanted
+    return changes
+
+
+def _join_group(module, array, group):
+    """Add the user to a group"""
+    res = post_with_context(
+        array,
+        "post_directory_services_local_users_members",
+        CONTEXT_VERSION,
+        module,
+        member_names=[module.params["name"]],
+        local_membership=LocalUserMembershipPost(
+            groups=[LocalusermembershippostGroups(group=Reference(name=group))]
+        ),
+        **_scope(module)
+    )
+    check_response(
+        res,
+        module,
+        "Failed to add local user {0} to group {1}".format(
+            module.params["name"], group
+        ),
+    )
+
+
+def _leave_group(module, array, group):
+    """Remove the user from a group"""
+    res = delete_with_context(
+        array,
+        "delete_directory_services_local_users_members",
+        CONTEXT_VERSION,
+        module,
+        member_names=[module.params["name"]],
+        group_names=[group],
+        **_scope(module)
+    )
+    check_response(
+        res,
+        module,
+        "Failed to remove local user {0} from group {1}".format(
+            module.params["name"], group
+        ),
+    )
+
+
+def _patch_user(module, array, target, **fields):
+    """Patch the named user with the given fields
+
+    The user to patch is positional and deliberately not called "name", so a
+    rename can pass name= as one of the fields without colliding with it.
+    """
+    res = patch_with_context(
+        array,
+        "patch_directory_services_local_users",
+        CONTEXT_VERSION,
+        module,
+        names=[target],
+        local_user=LocalUserPatch(**fields),
+        **_scope(module)
+    )
+    check_response(res, module, "Failed to update local user {0}".format(target))
+
+
+def create_user(module, array):
+    """Create a local user
+
+    The array refuses a create without both a password and a primary group, so
+    say which one is missing rather than passing the refusal through.
+    """
+    for required in ("password", "primary_group"):
+        if not module.params[required]:
+            module.fail_json(
+                msg="{0} is required to create local user {1}".format(
+                    required, module.params["name"]
+                )
+            )
+    if not module.check_mode:
+        res = post_with_context(
+            array,
+            "post_directory_services_local_users",
+            CONTEXT_VERSION,
+            module,
+            names=[module.params["name"]],
+            local_user=LocalUserPost(
+                password=module.params["password"],
+                primary_group=Reference(name=module.params["primary_group"]),
+                uid=module.params["uid"],
+                email=module.params["email"],
+                enabled=module.params["enabled"],
+            ),
+            **_scope(module)
+        )
+        check_response(
+            res,
+            module,
+            "Failed to create local user {0}".format(module.params["name"]),
+        )
+        for group in module.params["groups"] or []:
+            if group != module.params["primary_group"]:
+                _join_group(module, array, group)
+    module.exit_json(changed=True)
+
+
+def _reconcile_primary_group(module, array, user, memberships):
+    """Make the requested group the user's primary group
+
+    The array refuses to make a group primary unless the user is already a
+    member of it, so the membership goes in first.
+    """
+    wanted = module.params["primary_group"]
+    if not wanted or wanted == _primary_group_name(user):
+        return False
+    if not module.check_mode:
+        if wanted not in memberships:
+            _join_group(module, array, wanted)
+        _patch_user(
+            module, array, module.params["name"], primary_group=Reference(name=wanted)
+        )
+    return True
+
+
+def _reconcile_groups(module, array, user, memberships):
+    """Bring the user's other group memberships into line
+
+    Omitting the option leaves the memberships alone. The primary group is
+    always a membership and the array will not let it be removed, so it is
+    never in the removal set.
+    """
+    wanted = module.params["groups"]
+    if wanted is None:
+        return False
+    primary = module.params["primary_group"] or _primary_group_name(user)
+    wanted = {group for group in wanted if group != primary}
+    current = {group for group, is_primary in memberships.items() if not is_primary}
+    if primary:
+        current.discard(primary)
+    to_join = wanted - current
+    to_leave = current - wanted
+    if not module.check_mode:
+        for group in sorted(to_join):
+            _join_group(module, array, group)
+        for group in sorted(to_leave):
+            _leave_group(module, array, group)
+    return bool(to_join or to_leave)
+
+
+def update_user(module, array, user):
+    """Bring an existing local user into line with the play"""
+    changed = False
+    memberships = read_memberships(module, array, module.params["name"])
+
+    changes = _plain_changes(module, user)
+    if changes:
+        changed = True
+        if not module.check_mode:
+            _patch_user(module, array, module.params["name"], **changes)
+
+    if _reconcile_primary_group(module, array, user, memberships):
+        changed = True
+        memberships = (
+            memberships
+            if module.check_mode
+            else read_memberships(module, array, module.params["name"])
+        )
+
+    if _reconcile_groups(module, array, user, memberships):
+        changed = True
+
+    # A password cannot be read back, so there is nothing to compare it
+    # against. Only reset it when the play asks for that explicitly.
+    if module.params["password"] and module.params["update_password"] == "always":
+        changed = True
+        if not module.check_mode:
+            _patch_user(
+                module, array, module.params["name"], password=module.params["password"]
+            )
+
+    module.exit_json(changed=changed)
+
+
+def rename_user(module, array):
+    """Rename a local user"""
+    if read_user(module, array, module.params["rename"]):
+        module.fail_json(
+            msg="Target local user {0} already exists".format(module.params["rename"])
+        )
+    if not module.check_mode:
+        _patch_user(module, array, module.params["name"], name=module.params["rename"])
+    module.exit_json(changed=True)
+
+
+def check_renamed_user(module, array):
+    """Report on a rename whose source user has already gone
+
+    A completed rename leaves nothing under the old name, so a second run of
+    the same task must not create the source again.
+    """
+    if not read_user(module, array, module.params["rename"]):
+        module.fail_json(
+            msg="Local user {0} not found to rename".format(module.params["name"])
+        )
+    module.exit_json(changed=False)
+
+
+def delete_user(module, array, user):
+    """Delete a local user"""
+    if getattr(user, "built_in", False):
+        module.fail_json(
+            msg="Local user {0} is built-in and cannot be deleted".format(
+                module.params["name"]
+            )
+        )
+    if not module.check_mode:
+        res = delete_with_context(
+            array,
+            "delete_directory_services_local_users",
+            CONTEXT_VERSION,
+            module,
+            names=[module.params["name"]],
+            **_scope(module)
+        )
+        check_response(
+            res,
+            module,
+            "Failed to delete local user {0}".format(module.params["name"]),
+        )
+    module.exit_json(changed=True)
+
+
+def main():
+    argument_spec = purefa_argument_spec()
+    argument_spec.update(
+        dict(
+            state=dict(type="str", default="present", choices=["absent", "present"]),
+            name=dict(type="str", required=True),
+            local_directory_service=dict(type="str", required=True),
+            password=dict(type="str", no_log=True),
+            update_password=dict(
+                type="str",
+                default="on_create",
+                choices=["always", "on_create"],
+                no_log=False,
+            ),
+            primary_group=dict(type="str"),
+            groups=dict(type="list", elements="str"),
+            uid=dict(type="int"),
+            email=dict(type="str"),
+            enabled=dict(type="bool"),
+            rename=dict(type="str"),
+            context=dict(type="str", default=""),
+        )
+    )
+
+    module = AnsibleModule(argument_spec, supports_check_mode=True)
+
+    if not HAS_PURESTORAGE:
+        module.fail_json(msg="py-pure-client sdk is required for this module")
+
+    array = get_array(module)
+    check_api_version(array, USER_API_VERSION, module, "Local users")
+
+    state = module.params["state"]
+    user = read_user(module, array, module.params["name"])
+
+    if state == "present" and module.params["rename"]:
+        if user:
+            rename_user(module, array)
+        else:
+            check_renamed_user(module, array)
+    elif state == "present" and not user:
+        create_user(module, array)
+    elif state == "present":
+        update_user(module, array, user)
+    elif state == "absent" and user:
+        delete_user(module, array, user)
+
+    module.exit_json(changed=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -84,6 +84,7 @@ plugins/modules/purefa_info.py import-2.7
 plugins/modules/purefa_inventory.py import-2.7
 plugins/modules/purefa_kmip.py import-2.7
 plugins/modules/purefa_lds.py import-2.7
+plugins/modules/purefa_localgroup.py import-2.7
 plugins/modules/purefa_logging.py import-2.7
 plugins/modules/purefa_maintenance.py import-2.7
 plugins/modules/purefa_messages.py import-2.7

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -85,6 +85,7 @@ plugins/modules/purefa_inventory.py import-2.7
 plugins/modules/purefa_kmip.py import-2.7
 plugins/modules/purefa_lds.py import-2.7
 plugins/modules/purefa_localgroup.py import-2.7
+plugins/modules/purefa_localuser.py import-2.7
 plugins/modules/purefa_logging.py import-2.7
 plugins/modules/purefa_maintenance.py import-2.7
 plugins/modules/purefa_messages.py import-2.7

--- a/tests/unit/plugins/modules/test_purefa_localgroup.py
+++ b/tests/unit/plugins/modules/test_purefa_localgroup.py
@@ -1,0 +1,502 @@
+# Copyright: (c) 2026, Everpure Ansible Team <pure-ansible-team@everpuredata.com>
+# GNU General Public License v3.0+ (see COPYING.GPLv3 or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for purefa_localgroup module."""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import sys
+from unittest.mock import Mock, MagicMock, patch
+
+import pytest
+
+# Mock external dependencies before importing module
+sys.modules["grp"] = MagicMock()
+sys.modules["pwd"] = MagicMock()
+sys.modules["fcntl"] = MagicMock()
+sys.modules["ansible"] = MagicMock()
+sys.modules["ansible.module_utils"] = MagicMock()
+sys.modules["ansible.module_utils.basic"] = MagicMock()
+sys.modules["pypureclient"] = MagicMock()
+sys.modules["pypureclient.flasharray"] = MagicMock()
+sys.modules["ansible_collections"] = MagicMock()
+sys.modules["ansible_collections.everpure"] = MagicMock()
+sys.modules["ansible_collections.everpure.flasharray"] = MagicMock()
+sys.modules["ansible_collections.everpure.flasharray.plugins"] = MagicMock()
+sys.modules["ansible_collections.everpure.flasharray.plugins.module_utils"] = (
+    MagicMock()
+)
+sys.modules["ansible_collections.everpure.flasharray.plugins.module_utils.purefa"] = (
+    MagicMock()
+)
+sys.modules[
+    "ansible_collections.everpure.flasharray.plugins.module_utils.api_helpers"
+] = MagicMock()
+
+from plugins.modules.purefa_localgroup import (
+    read_group,
+    create_group,
+    update_group,
+    rename_group,
+    check_renamed_group,
+    delete_group,
+    _scope,
+    _wanted_changes,
+)
+
+
+def make_module(**params):
+    """An AnsibleModule stand-in whose fail_json raises, as the real one does"""
+    module = Mock()
+    module.check_mode = False
+    base = {
+        "name": "grp1",
+        "local_directory_service": "lds1",
+        "gid": None,
+        "email": None,
+        "rename": None,
+        "state": "present",
+        "context": "",
+    }
+    base.update(params)
+    module.params = base
+    module.fail_json.side_effect = SystemExit(1)
+    return module
+
+
+def make_group(name="grp1", gid=70001, email="a@example.com", built_in=False):
+    group = Mock()
+    group.name = name
+    group.gid = gid
+    group.email = email
+    group.built_in = built_in
+    return group
+
+
+class TestReadGroup:
+    """Test cases for read_group function"""
+
+    @patch("plugins.modules.purefa_localgroup.get_with_context")
+    def test_read_group_scopes_by_directory_service(self, mock_get):
+        """Test read_group narrows the lookup to one local directory service
+
+        A bare name matches the group of that name in every service on the
+        array, so the service has to be part of the query.
+        """
+        module = make_module()
+        group = make_group()
+        mock_get.return_value = Mock(status_code=200, items=[group])
+
+        assert read_group(module, Mock(), "grp1") is group
+        kwargs = mock_get.call_args[1]
+        assert kwargs["names"] == ["grp1"]
+        assert kwargs["filter"] == "local_directory_service.name='lds1'"
+
+    @patch("plugins.modules.purefa_localgroup.get_with_context")
+    def test_read_group_absent_is_400_not_404(self, mock_get):
+        """Test anything other than 200 counts as absent"""
+        module = make_module()
+        mock_get.return_value = Mock(status_code=400)
+
+        assert read_group(module, Mock(), "nope") is None
+
+    @patch("plugins.modules.purefa_localgroup.get_with_context")
+    def test_read_group_empty_items(self, mock_get):
+        """Test a 200 carrying nothing is absent"""
+        module = make_module()
+        mock_get.return_value = Mock(status_code=200, items=[])
+
+        assert read_group(module, Mock(), "grp1") is None
+
+
+class TestHelpers:
+    """Test cases for the scoping and diff helpers"""
+
+    def test_scope_names_the_directory_service(self):
+        """Test writes are aimed at one local directory service"""
+        module = make_module()
+
+        assert _scope(module) == {"local_directory_service_names": ["lds1"]}
+
+    def test_wanted_changes_ignores_omitted_options(self):
+        """Test an option the play leaves out is never a change"""
+        module = make_module()
+        group = make_group(gid=1, email="x@example.com")
+
+        assert _wanted_changes(module, group) == {}
+
+    def test_wanted_changes_ignores_matching_values(self):
+        """Test a setting that already matches is not a change"""
+        module = make_module(gid=70001, email="a@example.com")
+        group = make_group(gid=70001, email="a@example.com")
+
+        assert _wanted_changes(module, group) == {}
+
+    def test_wanted_changes_reports_differences_only(self):
+        """Test only the differing settings are collected"""
+        module = make_module(gid=70001, email="new@example.com")
+        group = make_group(gid=70001, email="old@example.com")
+
+        assert _wanted_changes(module, group) == {"email": "new@example.com"}
+
+
+class TestCreateGroup:
+    """Test cases for create_group function"""
+
+    def test_create_group_check_mode(self):
+        """Test create_group predicts the change without calling the array"""
+        module = make_module(gid=70001)
+        module.check_mode = True
+
+        create_group(module, Mock())
+
+        module.exit_json.assert_called_once_with(changed=True)
+
+    @patch("plugins.modules.purefa_localgroup.check_response")
+    @patch("plugins.modules.purefa_localgroup.post_with_context")
+    def test_create_group_scoped(self, mock_post, mock_check):
+        """Test create_group posts into the requested service"""
+        module = make_module(gid=70001, email="a@example.com")
+        mock_post.return_value = Mock(status_code=200)
+
+        create_group(module, Mock())
+
+        kwargs = mock_post.call_args[1]
+        assert kwargs["names"] == ["grp1"]
+        assert kwargs["local_directory_service_names"] == ["lds1"]
+        module.exit_json.assert_called_once_with(changed=True)
+
+
+class TestUpdateGroup:
+    """Test cases for update_group function"""
+
+    @patch("plugins.modules.purefa_localgroup.patch_with_context")
+    def test_update_group_nothing_requested(self, mock_patch):
+        """Test naming the group alone reports no change"""
+        module = make_module()
+        update_group(module, Mock(), make_group())
+
+        mock_patch.assert_not_called()
+        module.exit_json.assert_called_once_with(changed=False)
+
+    @patch("plugins.modules.purefa_localgroup.check_response")
+    @patch("plugins.modules.purefa_localgroup.patch_with_context")
+    def test_update_group_changes_email(self, mock_patch, mock_check):
+        """Test a differing setting is patched, scoped to the service"""
+        module = make_module(email="new@example.com")
+        mock_patch.return_value = Mock(status_code=200)
+
+        update_group(module, Mock(), make_group(email="old@example.com"))
+
+        assert mock_patch.call_args[1]["local_directory_service_names"] == ["lds1"]
+        module.exit_json.assert_called_once_with(changed=True)
+
+    @patch("plugins.modules.purefa_localgroup.patch_with_context")
+    def test_update_group_builtin_no_change_allowed(self, mock_patch):
+        """Test a built-in group with nothing asked of it is not an error"""
+        module = make_module()
+
+        update_group(module, Mock(), make_group(built_in=True))
+
+        mock_patch.assert_not_called()
+        module.exit_json.assert_called_once_with(changed=False)
+        module.fail_json.assert_not_called()
+
+    @patch("plugins.modules.purefa_localgroup.patch_with_context")
+    def test_update_group_builtin_change_fails(self, mock_patch):
+        """Test changing a built-in group fails before the array is called"""
+        module = make_module(email="nope@example.com")
+
+        with pytest.raises(SystemExit):
+            update_group(
+                module, Mock(), make_group(email="a@example.com", built_in=True)
+            )
+
+        assert "built-in" in module.fail_json.call_args[1]["msg"]
+        mock_patch.assert_not_called()
+
+    @patch("plugins.modules.purefa_localgroup.patch_with_context")
+    def test_update_group_check_mode(self, mock_patch):
+        """Test update_group predicts a change without making it"""
+        module = make_module(gid=70009)
+        module.check_mode = True
+
+        update_group(module, Mock(), make_group(gid=70001))
+
+        mock_patch.assert_not_called()
+        module.exit_json.assert_called_once_with(changed=True)
+
+
+class TestRenameGroup:
+    """Test cases for rename_group function"""
+
+    @patch("plugins.modules.purefa_localgroup.check_response")
+    @patch("plugins.modules.purefa_localgroup.patch_with_context")
+    @patch("plugins.modules.purefa_localgroup.read_group")
+    def test_rename_group_success(self, mock_read, mock_patch, mock_check):
+        """Test rename_group patches the new name when it is free"""
+        module = make_module(rename="grp2")
+        mock_read.return_value = None
+        mock_patch.return_value = Mock(status_code=200)
+
+        rename_group(module, Mock(), make_group())
+
+        assert mock_patch.call_args[1]["local_directory_service_names"] == ["lds1"]
+        module.exit_json.assert_called_once_with(changed=True)
+
+    @patch("plugins.modules.purefa_localgroup.patch_with_context")
+    @patch("plugins.modules.purefa_localgroup.read_group")
+    def test_rename_group_target_exists_fails(self, mock_read, mock_patch):
+        """Test renaming onto an existing group in the same service fails"""
+        module = make_module(rename="grp2")
+        mock_read.return_value = make_group(name="grp2")
+
+        with pytest.raises(SystemExit):
+            rename_group(module, Mock(), make_group())
+
+        assert "already exists" in module.fail_json.call_args[1]["msg"]
+        mock_patch.assert_not_called()
+
+    @patch("plugins.modules.purefa_localgroup.patch_with_context")
+    @patch("plugins.modules.purefa_localgroup.read_group")
+    def test_rename_group_builtin_fails(self, mock_read, mock_patch):
+        """Test a built-in group cannot be renamed"""
+        module = make_module(rename="grp2")
+
+        with pytest.raises(SystemExit):
+            rename_group(module, Mock(), make_group(built_in=True))
+
+        assert "built-in" in module.fail_json.call_args[1]["msg"]
+        mock_patch.assert_not_called()
+        mock_read.assert_not_called()
+
+
+class TestCheckRenamedGroup:
+    """Test cases for check_renamed_group, the second run of a rename"""
+
+    @patch("plugins.modules.purefa_localgroup.read_group")
+    def test_check_renamed_group_already_renamed(self, mock_read):
+        """Test no change is reported once the target is there"""
+        module = make_module(rename="grp2")
+        mock_read.return_value = make_group(name="grp2")
+
+        check_renamed_group(module, Mock())
+
+        module.exit_json.assert_called_once_with(changed=False)
+        module.fail_json.assert_not_called()
+
+    @patch("plugins.modules.purefa_localgroup.read_group")
+    def test_check_renamed_group_neither_exists_fails(self, mock_read):
+        """Test a rename with nothing to rename fails instead of creating"""
+        module = make_module(rename="grp2")
+        mock_read.return_value = None
+
+        with pytest.raises(SystemExit):
+            check_renamed_group(module, Mock())
+
+        assert "not found to rename" in module.fail_json.call_args[1]["msg"]
+        module.exit_json.assert_not_called()
+
+
+class TestDeleteGroup:
+    """Test cases for delete_group function"""
+
+    def test_delete_group_check_mode(self):
+        """Test delete_group predicts the change without calling the array"""
+        module = make_module(state="absent")
+        module.check_mode = True
+
+        delete_group(module, Mock(), make_group())
+
+        module.exit_json.assert_called_once_with(changed=True)
+
+    @patch("plugins.modules.purefa_localgroup.check_response")
+    @patch("plugins.modules.purefa_localgroup.delete_with_context")
+    def test_delete_group_scoped(self, mock_delete, mock_check):
+        """Test delete_group only targets the requested service"""
+        module = make_module(state="absent")
+        mock_delete.return_value = Mock(status_code=200)
+
+        delete_group(module, Mock(), make_group())
+
+        kwargs = mock_delete.call_args[1]
+        assert kwargs["names"] == ["grp1"]
+        assert kwargs["local_directory_service_names"] == ["lds1"]
+        module.exit_json.assert_called_once_with(changed=True)
+
+    @patch("plugins.modules.purefa_localgroup.delete_with_context")
+    def test_delete_group_builtin_fails(self, mock_delete):
+        """Test a built-in group cannot be deleted"""
+        module = make_module(state="absent")
+
+        with pytest.raises(SystemExit):
+            delete_group(module, Mock(), make_group(built_in=True))
+
+        assert "built-in" in module.fail_json.call_args[1]["msg"]
+        mock_delete.assert_not_called()
+
+
+class TestMain:
+    """Test cases for the main dispatch"""
+
+    @patch("plugins.modules.purefa_localgroup.get_array")
+    @patch("plugins.modules.purefa_localgroup.AnsibleModule")
+    def test_main_no_purestorage_sdk(self, mock_am, mock_ga):
+        """Test main fails when py-pure-client is missing"""
+        import plugins.modules.purefa_localgroup as mod
+
+        original = mod.HAS_PURESTORAGE
+        mod.HAS_PURESTORAGE = False
+        module = make_module()
+        mock_am.return_value = module
+        try:
+            with pytest.raises(SystemExit):
+                mod.main()
+            assert "sdk is required" in module.fail_json.call_args[1]["msg"]
+        finally:
+            mod.HAS_PURESTORAGE = original
+
+    @staticmethod
+    def _wire(mock_am, mock_ga, **params):
+        module = make_module(**params)
+        mock_am.return_value = module
+        array = Mock()
+        mock_ga.return_value = array
+        return module, array
+
+    @patch("plugins.modules.purefa_localgroup.create_group")
+    @patch("plugins.modules.purefa_localgroup.read_group")
+    @patch("plugins.modules.purefa_localgroup.check_api_version")
+    @patch("plugins.modules.purefa_localgroup.get_array")
+    @patch("plugins.modules.purefa_localgroup.AnsibleModule")
+    def test_main_creates_when_absent(
+        self, mock_am, mock_ga, mock_api, mock_read, mock_create
+    ):
+        """Test main creates a group the service does not hold"""
+        import plugins.modules.purefa_localgroup as mod
+
+        module, array = self._wire(mock_am, mock_ga)
+        mock_read.return_value = None
+
+        mod.main()
+
+        mock_create.assert_called_once_with(module, array)
+        mock_api.assert_called_once()
+
+    @patch("plugins.modules.purefa_localgroup.update_group")
+    @patch("plugins.modules.purefa_localgroup.read_group")
+    @patch("plugins.modules.purefa_localgroup.check_api_version")
+    @patch("plugins.modules.purefa_localgroup.get_array")
+    @patch("plugins.modules.purefa_localgroup.AnsibleModule")
+    def test_main_updates_when_present(
+        self, mock_am, mock_ga, mock_api, mock_read, mock_update
+    ):
+        """Test main reconciles a group that is already there"""
+        import plugins.modules.purefa_localgroup as mod
+
+        module, array = self._wire(mock_am, mock_ga, email="a@example.com")
+        group = make_group()
+        mock_read.return_value = group
+
+        mod.main()
+
+        mock_update.assert_called_once_with(module, array, group)
+
+    @patch("plugins.modules.purefa_localgroup.check_renamed_group")
+    @patch("plugins.modules.purefa_localgroup.create_group")
+    @patch("plugins.modules.purefa_localgroup.rename_group")
+    @patch("plugins.modules.purefa_localgroup.read_group")
+    @patch("plugins.modules.purefa_localgroup.check_api_version")
+    @patch("plugins.modules.purefa_localgroup.get_array")
+    @patch("plugins.modules.purefa_localgroup.AnsibleModule")
+    def test_main_rename_first_run(
+        self,
+        mock_am,
+        mock_ga,
+        mock_api,
+        mock_read,
+        mock_rename,
+        mock_create,
+        mock_checked,
+    ):
+        """First run: the source is there, so the rename happens"""
+        import plugins.modules.purefa_localgroup as mod
+
+        module, array = self._wire(mock_am, mock_ga, rename="grp2")
+        group = make_group()
+        mock_read.return_value = group
+
+        mod.main()
+
+        mock_rename.assert_called_once_with(module, array, group)
+        mock_create.assert_not_called()
+        mock_checked.assert_not_called()
+
+    @patch("plugins.modules.purefa_localgroup.check_renamed_group")
+    @patch("plugins.modules.purefa_localgroup.create_group")
+    @patch("plugins.modules.purefa_localgroup.rename_group")
+    @patch("plugins.modules.purefa_localgroup.read_group")
+    @patch("plugins.modules.purefa_localgroup.check_api_version")
+    @patch("plugins.modules.purefa_localgroup.get_array")
+    @patch("plugins.modules.purefa_localgroup.AnsibleModule")
+    def test_main_rename_second_run_does_not_create(
+        self,
+        mock_am,
+        mock_ga,
+        mock_api,
+        mock_read,
+        mock_rename,
+        mock_create,
+        mock_checked,
+    ):
+        """Second run: the source has gone, and must not be created again"""
+        import plugins.modules.purefa_localgroup as mod
+
+        module, array = self._wire(mock_am, mock_ga, rename="grp2")
+        mock_read.return_value = None
+
+        mod.main()
+
+        mock_checked.assert_called_once_with(module, array)
+        mock_create.assert_not_called()
+        mock_rename.assert_not_called()
+
+    @patch("plugins.modules.purefa_localgroup.delete_group")
+    @patch("plugins.modules.purefa_localgroup.read_group")
+    @patch("plugins.modules.purefa_localgroup.check_api_version")
+    @patch("plugins.modules.purefa_localgroup.get_array")
+    @patch("plugins.modules.purefa_localgroup.AnsibleModule")
+    def test_main_deletes_when_present(
+        self, mock_am, mock_ga, mock_api, mock_read, mock_delete
+    ):
+        """Test main deletes a group that is there"""
+        import plugins.modules.purefa_localgroup as mod
+
+        module, array = self._wire(mock_am, mock_ga, state="absent")
+        group = make_group()
+        mock_read.return_value = group
+
+        mod.main()
+
+        mock_delete.assert_called_once_with(module, array, group)
+
+    @patch("plugins.modules.purefa_localgroup.delete_group")
+    @patch("plugins.modules.purefa_localgroup.read_group")
+    @patch("plugins.modules.purefa_localgroup.check_api_version")
+    @patch("plugins.modules.purefa_localgroup.get_array")
+    @patch("plugins.modules.purefa_localgroup.AnsibleModule")
+    def test_main_absent_and_missing_is_no_change(
+        self, mock_am, mock_ga, mock_api, mock_read, mock_delete
+    ):
+        """Test removing something that is not there reports no change"""
+        import plugins.modules.purefa_localgroup as mod
+
+        module, array = self._wire(mock_am, mock_ga, state="absent")
+        mock_read.return_value = None
+
+        mod.main()
+
+        mock_delete.assert_not_called()
+        module.exit_json.assert_called_once_with(changed=False)

--- a/tests/unit/plugins/modules/test_purefa_localuser.py
+++ b/tests/unit/plugins/modules/test_purefa_localuser.py
@@ -1,0 +1,735 @@
+# Copyright: (c) 2026, Everpure Ansible Team <pure-ansible-team@everpuredata.com>
+# GNU General Public License v3.0+ (see COPYING.GPLv3 or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for purefa_localuser module."""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import sys
+from unittest.mock import Mock, MagicMock, patch
+
+import pytest
+
+# Mock external dependencies before importing module
+sys.modules["grp"] = MagicMock()
+sys.modules["pwd"] = MagicMock()
+sys.modules["fcntl"] = MagicMock()
+sys.modules["ansible"] = MagicMock()
+sys.modules["ansible.module_utils"] = MagicMock()
+sys.modules["ansible.module_utils.basic"] = MagicMock()
+sys.modules["pypureclient"] = MagicMock()
+sys.modules["pypureclient.flasharray"] = MagicMock()
+sys.modules["ansible_collections"] = MagicMock()
+sys.modules["ansible_collections.everpure"] = MagicMock()
+sys.modules["ansible_collections.everpure.flasharray"] = MagicMock()
+sys.modules["ansible_collections.everpure.flasharray.plugins"] = MagicMock()
+sys.modules["ansible_collections.everpure.flasharray.plugins.module_utils"] = (
+    MagicMock()
+)
+sys.modules["ansible_collections.everpure.flasharray.plugins.module_utils.purefa"] = (
+    MagicMock()
+)
+sys.modules[
+    "ansible_collections.everpure.flasharray.plugins.module_utils.api_helpers"
+] = MagicMock()
+
+from plugins.modules.purefa_localuser import (
+    read_user,
+    read_memberships,
+    create_user,
+    update_user,
+    rename_user,
+    check_renamed_user,
+    delete_user,
+    _scope,
+    _plain_changes,
+    _reconcile_groups,
+    _reconcile_primary_group,
+)
+
+
+def make_module(**params):
+    """An AnsibleModule stand-in whose fail_json raises, as the real one does"""
+    module = Mock()
+    module.check_mode = False
+    base = {
+        "name": "fred",
+        "local_directory_service": "lds1",
+        "password": None,
+        "update_password": "on_create",
+        "primary_group": None,
+        "groups": None,
+        "uid": None,
+        "email": None,
+        "enabled": None,
+        "rename": None,
+        "state": "present",
+        "context": "",
+    }
+    base.update(params)
+    module.params = base
+    module.fail_json.side_effect = SystemExit(1)
+    return module
+
+
+def make_user(
+    name="fred",
+    uid=71000,
+    email="a@example.com",
+    enabled=True,
+    primary="users",
+    built_in=False,
+):
+    user = Mock()
+    user.name = name
+    user.uid = uid
+    user.email = email
+    user.enabled = enabled
+    user.built_in = built_in
+    group = Mock()
+    group.name = primary
+    user.primary_group = group
+    return user
+
+
+def membership_row(group, is_primary):
+    row = Mock()
+    ref = Mock()
+    ref.name = group
+    row.group = ref
+    row.is_primary_group = is_primary
+    return row
+
+
+class TestReadUser:
+    """Test cases for read_user function"""
+
+    @patch("plugins.modules.purefa_localuser.get_with_context")
+    def test_read_user_scopes_by_directory_service(self, mock_get):
+        """Test read_user narrows the lookup to one local directory service"""
+        module = make_module()
+        user = make_user()
+        mock_get.return_value = Mock(status_code=200, items=[user])
+
+        assert read_user(module, Mock(), "fred") is user
+        kwargs = mock_get.call_args[1]
+        assert kwargs["names"] == ["fred"]
+        assert kwargs["filter"] == "local_directory_service.name='lds1'"
+
+    @patch("plugins.modules.purefa_localuser.get_with_context")
+    def test_read_user_absent_is_400_not_404(self, mock_get):
+        """Test anything other than 200 counts as absent"""
+        module = make_module()
+        mock_get.return_value = Mock(status_code=400)
+
+        assert read_user(module, Mock(), "nope") is None
+
+
+class TestReadMemberships:
+    """Test cases for read_memberships function"""
+
+    @patch("plugins.modules.purefa_localuser.get_with_context")
+    def test_read_memberships_maps_group_to_primary_flag(self, mock_get):
+        """Test memberships come back as {group: is primary}"""
+        module = make_module()
+        mock_get.return_value = Mock(
+            status_code=200,
+            items=[membership_row("users", True), membership_row("backup", False)],
+        )
+
+        assert read_memberships(module, Mock(), "fred") == {
+            "users": True,
+            "backup": False,
+        }
+
+    @patch("plugins.modules.purefa_localuser.get_with_context")
+    def test_read_memberships_filters_by_user_and_service(self, mock_get):
+        """Test the filter names both the user and the service"""
+        module = make_module()
+        mock_get.return_value = Mock(status_code=200, items=[])
+
+        read_memberships(module, Mock(), "fred")
+
+        assert mock_get.call_args[1]["filter"] == (
+            "member.name='fred' and local_directory_service.name='lds1'"
+        )
+
+    @patch("plugins.modules.purefa_localuser.get_with_context")
+    def test_read_memberships_absent(self, mock_get):
+        """Test a failed read is an empty mapping, not an error"""
+        module = make_module()
+        mock_get.return_value = Mock(status_code=400)
+
+        assert read_memberships(module, Mock(), "fred") == {}
+
+
+class TestHelpers:
+    """Test cases for the scoping and diff helpers"""
+
+    def test_scope_names_the_directory_service(self):
+        module = make_module()
+
+        assert _scope(module) == {"local_directory_service_names": ["lds1"]}
+
+    def test_plain_changes_ignores_omitted_options(self):
+        """Test an option the play leaves out is never a change"""
+        module = make_module()
+
+        assert _plain_changes(module, make_user()) == {}
+
+    def test_plain_changes_ignores_matching_values(self):
+        module = make_module(uid=71000, email="a@example.com", enabled=True)
+
+        assert _plain_changes(module, make_user()) == {}
+
+    def test_plain_changes_collects_differences(self):
+        module = make_module(uid=71000, email="new@example.com", enabled=False)
+
+        assert _plain_changes(module, make_user()) == {
+            "email": "new@example.com",
+            "enabled": False,
+        }
+
+    def test_plain_changes_handles_enabled_false(self):
+        """Test enabled=False is a change, not treated as unset"""
+        module = make_module(enabled=False)
+
+        assert _plain_changes(module, make_user(enabled=True)) == {"enabled": False}
+
+
+class TestReconcileGroups:
+    """Test cases for _reconcile_groups function"""
+
+    @patch("plugins.modules.purefa_localuser._leave_group")
+    @patch("plugins.modules.purefa_localuser._join_group")
+    def test_omitted_groups_leaves_membership_alone(self, mock_join, mock_leave):
+        """Test omitting the option is not a change"""
+        module = make_module()
+        memberships = {"users": True, "backup": False}
+
+        assert _reconcile_groups(module, Mock(), make_user(), memberships) is False
+        mock_join.assert_not_called()
+        mock_leave.assert_not_called()
+
+    @patch("plugins.modules.purefa_localuser._leave_group")
+    @patch("plugins.modules.purefa_localuser._join_group")
+    def test_matching_groups_is_no_change(self, mock_join, mock_leave):
+        module = make_module(groups=["backup"])
+        memberships = {"users": True, "backup": False}
+
+        assert _reconcile_groups(module, Mock(), make_user(), memberships) is False
+        mock_join.assert_not_called()
+        mock_leave.assert_not_called()
+
+    @patch("plugins.modules.purefa_localuser._leave_group")
+    @patch("plugins.modules.purefa_localuser._join_group")
+    def test_groups_are_added_and_removed(self, mock_join, mock_leave):
+        """Test the list is declarative in both directions"""
+        module = make_module(groups=["reporting"])
+        memberships = {"users": True, "backup": False}
+        array = Mock()
+
+        assert _reconcile_groups(module, array, make_user(), memberships) is True
+        mock_join.assert_called_once_with(module, array, "reporting")
+        mock_leave.assert_called_once_with(module, array, "backup")
+
+    @patch("plugins.modules.purefa_localuser._leave_group")
+    @patch("plugins.modules.purefa_localuser._join_group")
+    def test_empty_list_clears_the_extras_only(self, mock_join, mock_leave):
+        """Test an empty list removes secondaries but never the primary
+
+        The array refuses to remove the primary group's membership, so it must
+        never be in the removal set.
+        """
+        module = make_module(groups=[])
+        memberships = {"users": True, "backup": False}
+        array = Mock()
+
+        assert _reconcile_groups(module, array, make_user(), memberships) is True
+        mock_join.assert_not_called()
+        mock_leave.assert_called_once_with(module, array, "backup")
+
+    @patch("plugins.modules.purefa_localuser._leave_group")
+    @patch("plugins.modules.purefa_localuser._join_group")
+    def test_primary_group_listed_is_ignored(self, mock_join, mock_leave):
+        """Test naming the primary group in the list is not a change"""
+        module = make_module(groups=["users"])
+        memberships = {"users": True}
+
+        assert _reconcile_groups(module, Mock(), make_user(), memberships) is False
+        mock_join.assert_not_called()
+        mock_leave.assert_not_called()
+
+    @patch("plugins.modules.purefa_localuser._leave_group")
+    @patch("plugins.modules.purefa_localuser._join_group")
+    def test_check_mode_reports_without_acting(self, mock_join, mock_leave):
+        module = make_module(groups=["reporting"])
+        module.check_mode = True
+        memberships = {"users": True}
+
+        assert _reconcile_groups(module, Mock(), make_user(), memberships) is True
+        mock_join.assert_not_called()
+        mock_leave.assert_not_called()
+
+
+class TestReconcilePrimaryGroup:
+    """Test cases for _reconcile_primary_group function"""
+
+    @patch("plugins.modules.purefa_localuser._patch_user")
+    @patch("plugins.modules.purefa_localuser._join_group")
+    def test_no_primary_group_requested(self, mock_join, mock_patch):
+        module = make_module()
+
+        assert _reconcile_primary_group(module, Mock(), make_user(), {}) is False
+        mock_patch.assert_not_called()
+
+    @patch("plugins.modules.purefa_localuser._patch_user")
+    @patch("plugins.modules.purefa_localuser._join_group")
+    def test_primary_group_already_correct(self, mock_join, mock_patch):
+        module = make_module(primary_group="users")
+
+        assert (
+            _reconcile_primary_group(
+                module, Mock(), make_user(primary="users"), {"users": True}
+            )
+            is False
+        )
+        mock_patch.assert_not_called()
+
+    @patch("plugins.modules.purefa_localuser._patch_user")
+    @patch("plugins.modules.purefa_localuser._join_group")
+    def test_primary_group_joined_first_when_not_a_member(self, mock_join, mock_patch):
+        """Test the group is joined before being made primary
+
+        The array refuses a primary group the user does not belong to.
+        """
+        module = make_module(primary_group="backup")
+        array = Mock()
+
+        assert (
+            _reconcile_primary_group(
+                module, array, make_user(primary="users"), {"users": True}
+            )
+            is True
+        )
+        mock_join.assert_called_once_with(module, array, "backup")
+        mock_patch.assert_called_once()
+
+    @patch("plugins.modules.purefa_localuser._patch_user")
+    @patch("plugins.modules.purefa_localuser._join_group")
+    def test_primary_group_not_rejoined_when_already_a_member(
+        self, mock_join, mock_patch
+    ):
+        module = make_module(primary_group="backup")
+        array = Mock()
+
+        assert (
+            _reconcile_primary_group(
+                module,
+                array,
+                make_user(primary="users"),
+                {"users": True, "backup": False},
+            )
+            is True
+        )
+        mock_join.assert_not_called()
+        mock_patch.assert_called_once()
+
+
+class TestCreateUser:
+    """Test cases for create_user function"""
+
+    @patch("plugins.modules.purefa_localuser.post_with_context")
+    def test_create_user_requires_password(self, mock_post):
+        """Test the missing option is named rather than left to the array"""
+        module = make_module(primary_group="users")
+
+        with pytest.raises(SystemExit):
+            create_user(module, Mock())
+
+        assert "password is required" in module.fail_json.call_args[1]["msg"]
+        mock_post.assert_not_called()
+
+    @patch("plugins.modules.purefa_localuser.post_with_context")
+    def test_create_user_requires_primary_group(self, mock_post):
+        module = make_module(password="secret")
+
+        with pytest.raises(SystemExit):
+            create_user(module, Mock())
+
+        assert "primary_group is required" in module.fail_json.call_args[1]["msg"]
+        mock_post.assert_not_called()
+
+    def test_create_user_check_mode(self):
+        module = make_module(password="secret", primary_group="users")
+        module.check_mode = True
+
+        create_user(module, Mock())
+
+        module.exit_json.assert_called_once_with(changed=True)
+
+    @patch("plugins.modules.purefa_localuser._join_group")
+    @patch("plugins.modules.purefa_localuser.check_response")
+    @patch("plugins.modules.purefa_localuser.post_with_context")
+    def test_create_user_scoped(self, mock_post, mock_check, mock_join):
+        module = make_module(password="secret", primary_group="users")
+        mock_post.return_value = Mock(status_code=200)
+
+        create_user(module, Mock())
+
+        kwargs = mock_post.call_args[1]
+        assert kwargs["names"] == ["fred"]
+        assert kwargs["local_directory_service_names"] == ["lds1"]
+        mock_join.assert_not_called()
+        module.exit_json.assert_called_once_with(changed=True)
+
+    @patch("plugins.modules.purefa_localuser._join_group")
+    @patch("plugins.modules.purefa_localuser.check_response")
+    @patch("plugins.modules.purefa_localuser.post_with_context")
+    def test_create_user_joins_extra_groups(self, mock_post, mock_check, mock_join):
+        """Test extra groups are joined after the user exists"""
+        module = make_module(
+            password="secret", primary_group="users", groups=["backup", "users"]
+        )
+        array = Mock()
+        mock_post.return_value = Mock(status_code=200)
+
+        create_user(module, array)
+
+        # the primary group is already a membership and is not joined again
+        mock_join.assert_called_once_with(module, array, "backup")
+
+
+class TestUpdateUser:
+    """Test cases for update_user function"""
+
+    @patch("plugins.modules.purefa_localuser.read_memberships")
+    @patch("plugins.modules.purefa_localuser._patch_user")
+    def test_update_user_nothing_requested(self, mock_patch, mock_members):
+        """Test naming the user alone reports no change"""
+        module = make_module()
+        mock_members.return_value = {"users": True}
+
+        update_user(module, Mock(), make_user())
+
+        mock_patch.assert_not_called()
+        module.exit_json.assert_called_once_with(changed=False)
+
+    @patch("plugins.modules.purefa_localuser.read_memberships")
+    @patch("plugins.modules.purefa_localuser._patch_user")
+    def test_update_user_patches_plain_settings(self, mock_patch, mock_members):
+        module = make_module(email="new@example.com")
+        mock_members.return_value = {"users": True}
+
+        update_user(module, Mock(), make_user())
+
+        mock_patch.assert_called_once()
+        module.exit_json.assert_called_once_with(changed=True)
+
+    @patch("plugins.modules.purefa_localuser.read_memberships")
+    @patch("plugins.modules.purefa_localuser._patch_user")
+    def test_update_user_password_not_reset_by_default(self, mock_patch, mock_members):
+        """Test update_password on_create leaves an existing password alone
+
+        This is what keeps a task that carries a password idempotent.
+        """
+        module = make_module(password="secret")
+        mock_members.return_value = {"users": True}
+
+        update_user(module, Mock(), make_user())
+
+        mock_patch.assert_not_called()
+        module.exit_json.assert_called_once_with(changed=False)
+
+    @patch("plugins.modules.purefa_localuser.read_memberships")
+    @patch("plugins.modules.purefa_localuser._patch_user")
+    def test_update_user_password_reset_when_always(self, mock_patch, mock_members):
+        """Test update_password always resets and reports a change every run"""
+        module = make_module(password="secret", update_password="always")
+        mock_members.return_value = {"users": True}
+
+        update_user(module, Mock(), make_user())
+
+        mock_patch.assert_called_once()
+        assert mock_patch.call_args[1] == {"password": "secret"}
+        module.exit_json.assert_called_once_with(changed=True)
+
+    @patch("plugins.modules.purefa_localuser.read_memberships")
+    @patch("plugins.modules.purefa_localuser._patch_user")
+    def test_update_user_password_always_needs_a_password(
+        self, mock_patch, mock_members
+    ):
+        """Test update_password always with no password is not a change"""
+        module = make_module(update_password="always")
+        mock_members.return_value = {"users": True}
+
+        update_user(module, Mock(), make_user())
+
+        mock_patch.assert_not_called()
+        module.exit_json.assert_called_once_with(changed=False)
+
+
+class TestRenameUser:
+    """Test cases for rename_user function"""
+
+    @patch("plugins.modules.purefa_localuser._patch_user")
+    @patch("plugins.modules.purefa_localuser.read_user")
+    def test_rename_user_success(self, mock_read, mock_patch):
+        """Test the rename passes the new name as a field, not positionally"""
+        module = make_module(rename="freddy")
+        mock_read.return_value = None
+        array = Mock()
+
+        rename_user(module, array)
+
+        mock_patch.assert_called_once_with(module, array, "fred", name="freddy")
+        module.exit_json.assert_called_once_with(changed=True)
+
+    @patch("plugins.modules.purefa_localuser._patch_user")
+    @patch("plugins.modules.purefa_localuser.read_user")
+    def test_rename_user_target_exists_fails(self, mock_read, mock_patch):
+        module = make_module(rename="freddy")
+        mock_read.return_value = make_user(name="freddy")
+
+        with pytest.raises(SystemExit):
+            rename_user(module, Mock())
+
+        assert "already exists" in module.fail_json.call_args[1]["msg"]
+        mock_patch.assert_not_called()
+
+    @patch("plugins.modules.purefa_localuser._patch_user")
+    @patch("plugins.modules.purefa_localuser.read_user")
+    def test_rename_user_check_mode(self, mock_read, mock_patch):
+        module = make_module(rename="freddy")
+        module.check_mode = True
+        mock_read.return_value = None
+
+        rename_user(module, Mock())
+
+        mock_patch.assert_not_called()
+        module.exit_json.assert_called_once_with(changed=True)
+
+
+class TestCheckRenamedUser:
+    """Test cases for check_renamed_user, the second run of a rename"""
+
+    @patch("plugins.modules.purefa_localuser.read_user")
+    def test_already_renamed(self, mock_read):
+        module = make_module(rename="freddy")
+        mock_read.return_value = make_user(name="freddy")
+
+        check_renamed_user(module, Mock())
+
+        module.exit_json.assert_called_once_with(changed=False)
+        module.fail_json.assert_not_called()
+
+    @patch("plugins.modules.purefa_localuser.read_user")
+    def test_neither_exists_fails(self, mock_read):
+        module = make_module(rename="freddy")
+        mock_read.return_value = None
+
+        with pytest.raises(SystemExit):
+            check_renamed_user(module, Mock())
+
+        assert "not found to rename" in module.fail_json.call_args[1]["msg"]
+        module.exit_json.assert_not_called()
+
+
+class TestDeleteUser:
+    """Test cases for delete_user function"""
+
+    @patch("plugins.modules.purefa_localuser.check_response")
+    @patch("plugins.modules.purefa_localuser.delete_with_context")
+    def test_delete_user_scoped(self, mock_delete, mock_check):
+        module = make_module(state="absent")
+        mock_delete.return_value = Mock(status_code=200)
+
+        delete_user(module, Mock(), make_user())
+
+        kwargs = mock_delete.call_args[1]
+        assert kwargs["names"] == ["fred"]
+        assert kwargs["local_directory_service_names"] == ["lds1"]
+        module.exit_json.assert_called_once_with(changed=True)
+
+    @patch("plugins.modules.purefa_localuser.delete_with_context")
+    def test_delete_user_builtin_fails(self, mock_delete):
+        """Test a built-in user cannot be deleted
+
+        Unlike built-in groups, built-in users can be modified - only the
+        delete is refused.
+        """
+        module = make_module(state="absent")
+
+        with pytest.raises(SystemExit):
+            delete_user(module, Mock(), make_user(built_in=True))
+
+        assert "built-in" in module.fail_json.call_args[1]["msg"]
+        mock_delete.assert_not_called()
+
+    def test_delete_user_check_mode(self):
+        module = make_module(state="absent")
+        module.check_mode = True
+
+        delete_user(module, Mock(), make_user())
+
+        module.exit_json.assert_called_once_with(changed=True)
+
+
+class TestMain:
+    """Test cases for the main dispatch"""
+
+    @patch("plugins.modules.purefa_localuser.get_array")
+    @patch("plugins.modules.purefa_localuser.AnsibleModule")
+    def test_main_no_purestorage_sdk(self, mock_am, mock_ga):
+        import plugins.modules.purefa_localuser as mod
+
+        original = mod.HAS_PURESTORAGE
+        mod.HAS_PURESTORAGE = False
+        module = make_module()
+        mock_am.return_value = module
+        try:
+            with pytest.raises(SystemExit):
+                mod.main()
+            assert "sdk is required" in module.fail_json.call_args[1]["msg"]
+        finally:
+            mod.HAS_PURESTORAGE = original
+
+    @staticmethod
+    def _wire(mock_am, mock_ga, **params):
+        module = make_module(**params)
+        mock_am.return_value = module
+        array = Mock()
+        mock_ga.return_value = array
+        return module, array
+
+    @patch("plugins.modules.purefa_localuser.create_user")
+    @patch("plugins.modules.purefa_localuser.read_user")
+    @patch("plugins.modules.purefa_localuser.check_api_version")
+    @patch("plugins.modules.purefa_localuser.get_array")
+    @patch("plugins.modules.purefa_localuser.AnsibleModule")
+    def test_main_creates_when_absent(
+        self, mock_am, mock_ga, mock_api, mock_read, mock_create
+    ):
+        import plugins.modules.purefa_localuser as mod
+
+        module, array = self._wire(mock_am, mock_ga)
+        mock_read.return_value = None
+
+        mod.main()
+
+        mock_create.assert_called_once_with(module, array)
+        mock_api.assert_called_once()
+
+    @patch("plugins.modules.purefa_localuser.update_user")
+    @patch("plugins.modules.purefa_localuser.read_user")
+    @patch("plugins.modules.purefa_localuser.check_api_version")
+    @patch("plugins.modules.purefa_localuser.get_array")
+    @patch("plugins.modules.purefa_localuser.AnsibleModule")
+    def test_main_updates_when_present(
+        self, mock_am, mock_ga, mock_api, mock_read, mock_update
+    ):
+        import plugins.modules.purefa_localuser as mod
+
+        module, array = self._wire(mock_am, mock_ga, email="a@example.com")
+        user = make_user()
+        mock_read.return_value = user
+
+        mod.main()
+
+        mock_update.assert_called_once_with(module, array, user)
+
+    @patch("plugins.modules.purefa_localuser.check_renamed_user")
+    @patch("plugins.modules.purefa_localuser.create_user")
+    @patch("plugins.modules.purefa_localuser.rename_user")
+    @patch("plugins.modules.purefa_localuser.read_user")
+    @patch("plugins.modules.purefa_localuser.check_api_version")
+    @patch("plugins.modules.purefa_localuser.get_array")
+    @patch("plugins.modules.purefa_localuser.AnsibleModule")
+    def test_main_rename_first_run(
+        self,
+        mock_am,
+        mock_ga,
+        mock_api,
+        mock_read,
+        mock_rename,
+        mock_create,
+        mock_checked,
+    ):
+        """First run: the source is there, so the rename happens"""
+        import plugins.modules.purefa_localuser as mod
+
+        module, array = self._wire(mock_am, mock_ga, rename="freddy")
+        mock_read.return_value = make_user()
+
+        mod.main()
+
+        mock_rename.assert_called_once_with(module, array)
+        mock_create.assert_not_called()
+        mock_checked.assert_not_called()
+
+    @patch("plugins.modules.purefa_localuser.check_renamed_user")
+    @patch("plugins.modules.purefa_localuser.create_user")
+    @patch("plugins.modules.purefa_localuser.rename_user")
+    @patch("plugins.modules.purefa_localuser.read_user")
+    @patch("plugins.modules.purefa_localuser.check_api_version")
+    @patch("plugins.modules.purefa_localuser.get_array")
+    @patch("plugins.modules.purefa_localuser.AnsibleModule")
+    def test_main_rename_second_run_does_not_create(
+        self,
+        mock_am,
+        mock_ga,
+        mock_api,
+        mock_read,
+        mock_rename,
+        mock_create,
+        mock_checked,
+    ):
+        """Second run: the source has gone, and must not be created again"""
+        import plugins.modules.purefa_localuser as mod
+
+        module, array = self._wire(mock_am, mock_ga, rename="freddy")
+        mock_read.return_value = None
+
+        mod.main()
+
+        mock_checked.assert_called_once_with(module, array)
+        mock_create.assert_not_called()
+        mock_rename.assert_not_called()
+
+    @patch("plugins.modules.purefa_localuser.delete_user")
+    @patch("plugins.modules.purefa_localuser.read_user")
+    @patch("plugins.modules.purefa_localuser.check_api_version")
+    @patch("plugins.modules.purefa_localuser.get_array")
+    @patch("plugins.modules.purefa_localuser.AnsibleModule")
+    def test_main_deletes_when_present(
+        self, mock_am, mock_ga, mock_api, mock_read, mock_delete
+    ):
+        import plugins.modules.purefa_localuser as mod
+
+        module, array = self._wire(mock_am, mock_ga, state="absent")
+        user = make_user()
+        mock_read.return_value = user
+
+        mod.main()
+
+        mock_delete.assert_called_once_with(module, array, user)
+
+    @patch("plugins.modules.purefa_localuser.delete_user")
+    @patch("plugins.modules.purefa_localuser.read_user")
+    @patch("plugins.modules.purefa_localuser.check_api_version")
+    @patch("plugins.modules.purefa_localuser.get_array")
+    @patch("plugins.modules.purefa_localuser.AnsibleModule")
+    def test_main_absent_and_missing_is_no_change(
+        self, mock_am, mock_ga, mock_api, mock_read, mock_delete
+    ):
+        import plugins.modules.purefa_localuser as mod
+
+        module, array = self._wire(mock_am, mock_ga, state="absent")
+        mock_read.return_value = None
+
+        mod.main()
+
+        mock_delete.assert_not_called()
+        module.exit_json.assert_called_once_with(changed=False)


### PR DESCRIPTION
##### SUMMARY

Last of the local directory services set, after #1052 and #1053. Users inside a
local directory service, and the groups they belong to, could not be managed at
all.

As with `purefa_localgroup`, `local_directory_service` is required and every call
is scoped by it, because user names repeat in every service — and REST 2.44 for
the same reason: the scoping parameters arrived with the service object, and
without them a request cannot be aimed reliably.

##### What the array taught me, and how it changed the design

Nearly every decision here came from probing hardware rather than reading the
models:

| Behaviour | Consequence for the module |
| --- | --- |
| A create needs **both** `password` and `primary_group` — either alone is refused | the module names whichever is missing rather than passing the array's `Missing or invalid parameter.` through |
| **A password cannot be read back** — the model has no password field at all | nothing to compare against, so always sending it would make every run report a change. `update_password` defaults to `on_create`, with `always` as the escape hatch |
| The array refuses to make a group primary unless the user already belongs to it (`Need to be a member of group before assigning as primary group.`) | the module joins the group first, then sets it primary |
| The primary group's membership **cannot be removed** (`Local membership does not exist.`) | it is never in the removal set for the declarative `groups` list |
| Adding a membership that already exists is refused | memberships are read before being changed |
| **Built-in users can be modified** — unlike built-in groups — but not deleted | only the delete is guarded; modifying is how a password gets set on a new service's `Administrator` |
| A user name is limited to 20 characters, with a list of forbidden symbols | documented in `notes:` |

`groups` is declarative in both directions, and omitting it leaves memberships
alone.

##### On `update_password`

This differs from `purefa_user`, which uses `old_password` and is documented as
not idempotent. That module works against the array-admin API, which requires the
old password; this API does not, and it will happily accept the same password
repeatedly — reporting a change every time. Since a password is unreadable, the
only way to keep a password-carrying task idempotent is not to send it unless
asked, which is what `update_password: on_create` does. `always` reports a change
on every run, and the documentation says why rather than implying it is a bug.

##### ISSUE TYPE

- New Module Pull Request

##### COMPONENT NAME

purefa_localuser

##### ADDITIONAL INFORMATION

Validated on the same array with a playbook that runs every action twice:

```
TASK [Both must fail naming the missing option] ***  ok
TASK [Create must change once, then report no change despite the password] ***  ok
TASK [update_password always must report a change every run] ***  ok
TASK [Settings change must change once then report no change] ***  ok
TASK [An options-free present task is idempotent] ***  ok
TASK [Group membership must change once then report no change] ***  ok
TASK [A declarative group list must add and remove, then settle] ***  ok
TASK [An empty list must clear the extras, then settle] ***  ok
TASK [An omitted group list is not a change] ***  ok
TASK [The module must join the group first, then settle] ***  ok
TASK [Rename must change once then report no change] ***  ok
TASK [A rename with nothing to rename must fail] ***  ok
TASK [Built-in users are modifiable but not deletable] ***  ok
TASK [Delete must change once then report no change] ***  ok

PLAY RECAP
localhost : ok=44  changed=15  unreachable=0  failed=0
```

Test passwords are generated locally and passed in by environment, so no password
appears in the playbook, on a command line, or in any log. The play builds its
own local directory service and removes it at the end, so the array's own
`domain` service — the one `_array_server` depends on — was never touched, and
the array finished byte-identical to the baseline taken first.

**Two defects the hardware run found**, both fixed here rather than shipped:
`_patch_user`'s positional parameter was called `name`, so a rename passing
`name=` as a field collided with it (`TypeError: got multiple values for
argument 'name'`); and `update_password` needed an explicit `no_log=False`, since
Ansible warns on any option whose name looks like a secret. A third came from
sanity: the name-constraint note listed the forbidden symbols with a
colon-space, which YAML reads as a mapping, so the whole `DOCUMENTATION` block
stopped parsing. The doc block is now checked with `yaml.safe_load` as part of
the fix.

45 unit tests cover the scoped read and membership read, the diff helper, both
reconcilers (including that an empty `groups` list never touches the primary
group, and that a listed primary group is ignored), create with each required
option missing, both `update_password` modes, rename passing the name as a field
rather than positionally, the built-in delete guard, check mode on every write
path, and the `main()` dispatch including both runs of a rename.

`ansible-test sanity --local` passes. No f-strings, so no `compile-2.7` ignore
entry is needed.

No changelog fragment: antsibull generates the "New Modules" entry from
`short_description`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
