### PR TITLE
feat(purefa_tags): Add resource tags module, and fix purefa_volume_tags removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ All modules are idempotent with the exception of modules that change or set pass
 - purefa_subnet - manage network subnets on the FlashArray
 - purefa_syslog - manage the Syslog settings on the FlashArray
 - purefa_syslog_settings - manage the global syslog server settings on the FlashArray
+- purefa_tags - manage tags on FlashArray resources
 - purefa_tgroup - manage topology groups and their memberships on the FlashArray
 - purefa_token - manage FlashArray user API tokens
 - purefa_timeout - manage the GUI idle timeout on the FlashArray

--- a/changelogs/fragments/1055_put_with_context.yaml
+++ b/changelogs/fragments/1055_put_with_context.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+  - api_helpers - Add put_with_context, the verb alias the helper family was
+    missing. PUT endpoints were previously reached through get_with_context.

--- a/changelogs/fragments/1055_put_with_context.yaml
+++ b/changelogs/fragments/1055_put_with_context.yaml
@@ -1,6 +1,9 @@
 minor_changes:
   - api_helpers - Add put_with_context, the verb alias the helper family was
     missing. PUT endpoints were previously reached through get_with_context.
+  - purefa_volume_tags - Warn that the module is superseded by
+    M(everpure.flasharray.purefa_tags), which manages volume tags as well as
+    tags on every other taggable resource.
 bugfixes:
   - purefa_volume_tags - Fix I(state=absent) so that it actually removes tags.
     The keys from I(kvp) were compared as single-element tuples against key

--- a/changelogs/fragments/1055_put_with_context.yaml
+++ b/changelogs/fragments/1055_put_with_context.yaml
@@ -1,3 +1,12 @@
 minor_changes:
   - api_helpers - Add put_with_context, the verb alias the helper family was
     missing. PUT endpoints were previously reached through get_with_context.
+bugfixes:
+  - purefa_volume_tags - Fix I(state=absent) so that it actually removes tags.
+    The keys from I(kvp) were compared as single-element tuples against key
+    strings, so nothing ever matched and the module reported no change.
+  - purefa_volume_tags - Fix the I(tag) option, which was documented and
+    accepted but never read, so removing tags by key did nothing. Used on its
+    own it also raised a TypeError.
+  - purefa_volume_tags - Accept C(keys) as an alias for I(tag), matching the
+    option name used by M(everpure.flasharray.purefa_tags).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -65,6 +65,7 @@ action_groups:
    - purefa_subnet
    - purefa_syslog
    - purefa_syslog_settings
+   - purefa_tags
    - purefa_tgroup
    - purefa_timeout
    - purefa_token

--- a/plugins/module_utils/api_helpers.py
+++ b/plugins/module_utils/api_helpers.py
@@ -134,6 +134,14 @@ def delete_with_context(client, method_name, context_version, module, **kwargs):
     return get_with_context(client, method_name, context_version, module, **kwargs)
 
 
+def put_with_context(client, method_name, context_version, module, **kwargs):
+    """Alias for get_with_context for PUT operations.
+
+    Identical to get_with_context but named for clarity when doing PUT operations.
+    """
+    return get_with_context(client, method_name, context_version, module, **kwargs)
+
+
 def post_with_throttle_and_context(
     client, method_name, throttle_version, context_version, module, **kwargs
 ):

--- a/plugins/modules/purefa_tags.py
+++ b/plugins/modules/purefa_tags.py
@@ -1,0 +1,404 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2026, Simon Dodsley (simon@everpuredata.com)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+DOCUMENTATION = r"""
+---
+module: purefa_tags
+version_added: '1.45.0'
+short_description: Manage Everpure FlashArray resource tags
+description:
+- Add, change and remove key/value tags on Everpure FlashArray resources.
+- One module covers every taggable resource type. Which type is being tagged is
+  given by I(resource_type), and the resource itself by I(name).
+- Volumes are not included. They have their own module,
+  M(everpure.flasharray.purefa_volume_tags), which also exposes the volume-only
+  behaviour of I(copyable).
+author:
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@everpuredata.com>
+options:
+  resource_type:
+    description:
+    - The kind of resource to tag.
+    - C(array) tags the array itself and takes no I(name).
+    - Each type became taggable in a different Purity//FA release, so the
+      module checks the REST version for the type requested rather than one
+      version for all of them.
+    type: str
+    required: true
+    choices:
+    - array
+    - host
+    - host_group
+    - pod
+    - protection_group
+    - protection_group_snapshot
+    - realm
+    - volume_group
+    - volume_snapshot
+    - workload
+  name:
+    description:
+    - Name of the resource to tag.
+    - Required for every I(resource_type) except C(array), which is the array
+      the module is talking to.
+    type: str
+  namespace:
+    description:
+    - The tag namespace to work in.
+    - Namespaces are independent - the same key can hold a different value in
+      each, and a tag is only ever read, written or removed in the namespace
+      named here.
+    default: default
+    type: str
+  kvp:
+    description:
+    - List of key value pairs to set on the resource.
+    - Separate the key from the value using a colon (:) only.
+    - Required when I(state=present).
+    - With I(state=absent) and no I(keys), the keys of these pairs are the tags
+      removed, and their values are ignored.
+    type: list
+    elements: str
+  keys:
+    description:
+    - List of tag keys to remove, for use with I(state=absent).
+    - Takes precedence over the keys in I(kvp).
+    type: list
+    elements: str
+  copyable:
+    description:
+    - Whether the tag is inherited by copies of the resource.
+    - Only the volume family honours this. The array accepts it for the other
+      resource types and silently stores C(true) regardless, so it is only
+      compared, and only reported as a change, for C(volume_group) and
+      C(volume_snapshot).
+    - Omit it to let the array use its own default.
+    type: bool
+  state:
+    description:
+    - Define whether the tags should exist or not.
+    default: present
+    choices: [ absent, present ]
+    type: str
+  context:
+    description:
+    - Name of fleet member on which to perform the operation.
+    - This requires the array receiving the request is a member of a fleet
+      and the context name to be a member of the same fleet.
+    type: str
+    default: ""
+extends_documentation_fragment:
+- everpure.flasharray.everpure.fa
+notes:
+- The minimum Purity//FA REST version depends on I(resource_type)
+  - C(volume_snapshot) from 2.2, C(array), C(host) and C(host_group) from 2.34,
+  C(pod), C(protection_group) and C(volume_group) from 2.39, C(workload) from
+  2.40, C(realm) from 2.41 and C(protection_group_snapshot) from 2.44.
+- Tagging a resource that does not exist fails with the array's own message,
+  which names the resource type.
+- Cloud provider tags, which propagate to the cloud a Cloud Block Store
+  instance runs in, are a separate namespace of their own and are not managed
+  here.
+"""
+
+EXAMPLES = r"""
+- name: Tag host foo
+  everpure.flasharray.purefa_tags:
+    resource_type: host
+    name: foo
+    kvp:
+    - env:production
+    - owner:infra
+    fa_url: 10.10.10.2
+    api_token: e31060a7-21fc-e277-6240-25983c6c4592
+
+- name: Tag the array itself
+  everpure.flasharray.purefa_tags:
+    resource_type: array
+    kvp:
+    - site:london
+    fa_url: 10.10.10.2
+    api_token: e31060a7-21fc-e277-6240-25983c6c4592
+
+- name: Tag a volume group so copies inherit the tag
+  everpure.flasharray.purefa_tags:
+    resource_type: volume_group
+    name: bar
+    kvp:
+    - backup:nightly
+    copyable: true
+    fa_url: 10.10.10.2
+    api_token: e31060a7-21fc-e277-6240-25983c6c4592
+
+- name: Tag a protection group in its own namespace
+  everpure.flasharray.purefa_tags:
+    resource_type: protection_group
+    name: pgroup1
+    namespace: reporting
+    kvp:
+    - tier:gold
+    fa_url: 10.10.10.2
+    api_token: e31060a7-21fc-e277-6240-25983c6c4592
+
+- name: Remove two tags from host foo
+  everpure.flasharray.purefa_tags:
+    resource_type: host
+    name: foo
+    keys:
+    - env
+    - owner
+    state: absent
+    fa_url: 10.10.10.2
+    api_token: e31060a7-21fc-e277-6240-25983c6c4592
+"""
+
+RETURN = r"""
+"""
+
+HAS_PURESTORAGE = True
+try:
+    from pypureclient.flasharray import Tag, TagBatch
+except ImportError:
+    HAS_PURESTORAGE = False
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.everpure.flasharray.plugins.module_utils.purefa import (
+    get_array,
+    purefa_argument_spec,
+)
+from ansible_collections.everpure.flasharray.plugins.module_utils.api_helpers import (
+    check_api_version,
+    check_response,
+    delete_with_context,
+    get_with_context,
+    put_with_context,
+)
+
+CONTEXT_VERSION = "2.38"
+
+# Each resource type, the name it goes by in the API, and the REST version its
+# tag endpoints arrived in. The versions differ widely, so the guardrail is per
+# type rather than one floor for the module.
+RESOURCES = {
+    "array": ("arrays", "2.34"),
+    "host": ("hosts", "2.34"),
+    "host_group": ("host_groups", "2.34"),
+    "pod": ("pods", "2.39"),
+    "protection_group": ("protection_groups", "2.39"),
+    "protection_group_snapshot": ("protection_group_snapshots", "2.44"),
+    "realm": ("realms", "2.41"),
+    "volume_group": ("volume_groups", "2.39"),
+    "volume_snapshot": ("volume_snapshots", "2.2"),
+    "workload": ("workloads", "2.40"),
+}
+
+# The array is a singleton, so its tag endpoints take no resource name, and the
+# write is a plain put rather than the batch form every other type uses.
+SINGLETON = "array"
+
+# Only the volume family stores copyable as given. The others accept the field
+# and report true whatever was sent, so comparing it there would make a play
+# that sets copyable=false report a change on every run.
+COPYABLE_TYPES = ("volume_group", "volume_snapshot")
+
+
+def _api_name(module):
+    """The API's name for the requested resource type"""
+    return RESOURCES[module.params["resource_type"]][0]
+
+
+def _resource_args(module):
+    """The parameters that name the resource being tagged"""
+    if module.params["resource_type"] == SINGLETON:
+        return {}
+    return {"resource_names": [module.params["name"]]}
+
+
+def _compares_copyable(module):
+    """Whether copyable is worth comparing for this resource type"""
+    return (
+        module.params["copyable"] is not None
+        and module.params["resource_type"] in COPYABLE_TYPES
+    )
+
+
+def parse_kvp(module):
+    """Return the requested tags as a list of (key, value)
+
+    A pair is split on the first colon only, so a value may contain one.
+    """
+    pairs = []
+    for item in module.params["kvp"] or []:
+        if ":" not in item:
+            module.fail_json(msg="kvp entry {0} is not in key:value form".format(item))
+        key, value = item.split(":", 1)
+        if not key:
+            module.fail_json(msg="kvp entry {0} has an empty key".format(item))
+        pairs.append((key, value))
+    return pairs
+
+
+def read_tags(module, array):
+    """Return the resource's tags in the requested namespace
+
+    The namespace is always sent - a read that leaves it out comes back with
+    the default namespace only, which would make tags in any other namespace
+    invisible.
+    """
+    res = get_with_context(
+        array,
+        "get_{0}_tags".format(_api_name(module)),
+        CONTEXT_VERSION,
+        module,
+        namespaces=[module.params["namespace"]],
+        **_resource_args(module)
+    )
+    if res.status_code != 200:
+        check_response(
+            res,
+            module,
+            "Failed to read tags for {0}".format(module.params["name"] or "the array"),
+        )
+    return list(res.items)
+
+
+def _write_tags(module, array, pairs):
+    """Write the given (key, value) pairs as tags"""
+    fields = {"namespace": module.params["namespace"]}
+    if module.params["copyable"] is not None:
+        fields["copyable"] = module.params["copyable"]
+    if module.params["resource_type"] == SINGLETON:
+        method = "put_arrays_tags"
+        tags = [Tag(key=key, value=value, **fields) for key, value in pairs]
+    else:
+        method = "put_{0}_tags_batch".format(_api_name(module))
+        tags = [TagBatch(key=key, value=value, **fields) for key, value in pairs]
+    res = put_with_context(
+        array, method, CONTEXT_VERSION, module, tag=tags, **_resource_args(module)
+    )
+    check_response(
+        res,
+        module,
+        "Failed to set tags on {0}".format(module.params["name"] or "the array"),
+    )
+
+
+def apply_tags(module, array, current):
+    """Set the requested tags, writing only the ones that differ
+
+    A put is accepted whether or not anything changes, so the difference has to
+    be worked out here for the module to report honestly.
+    """
+    pairs = parse_kvp(module)
+    if not pairs:
+        module.fail_json(msg="kvp is required to set tags")
+    held = {tag.key: tag for tag in current}
+    wanted = []
+    for key, value in pairs:
+        tag = held.get(key)
+        if tag is None or tag.value != value:
+            wanted.append((key, value))
+        elif _compares_copyable(module) and (
+            getattr(tag, "copyable", None) != module.params["copyable"]
+        ):
+            wanted.append((key, value))
+    if wanted and not module.check_mode:
+        _write_tags(module, array, wanted)
+    module.exit_json(changed=bool(wanted))
+
+
+def remove_tags(module, array, current):
+    """Remove the requested tags
+
+    A delete of a key that is not there is accepted too, so again the work is
+    in deciding what actually needs removing.
+    """
+    if module.params["keys"]:
+        requested = list(module.params["keys"])
+    else:
+        requested = [key for key, _value in parse_kvp(module)]
+    if not requested:
+        module.fail_json(msg="keys or kvp is required to remove tags")
+    held = {tag.key for tag in current}
+    doomed = sorted(set(requested) & held)
+    if doomed and not module.check_mode:
+        res = delete_with_context(
+            array,
+            "delete_{0}_tags".format(_api_name(module)),
+            CONTEXT_VERSION,
+            module,
+            keys=doomed,
+            namespaces=[module.params["namespace"]],
+            **_resource_args(module)
+        )
+        check_response(
+            res,
+            module,
+            "Failed to remove tags from {0}".format(
+                module.params["name"] or "the array"
+            ),
+        )
+    module.exit_json(changed=bool(doomed))
+
+
+def main():
+    argument_spec = purefa_argument_spec()
+    argument_spec.update(
+        dict(
+            state=dict(type="str", default="present", choices=["absent", "present"]),
+            resource_type=dict(type="str", required=True, choices=sorted(RESOURCES)),
+            name=dict(type="str"),
+            namespace=dict(type="str", default="default"),
+            kvp=dict(type="list", elements="str"),
+            keys=dict(type="list", elements="str", no_log=False),
+            copyable=dict(type="bool"),
+            context=dict(type="str", default=""),
+        )
+    )
+
+    # Every type except the array is a named resource
+    required_if = [
+        ["resource_type", value, ["name"]] for value in RESOURCES if value != SINGLETON
+    ]
+
+    module = AnsibleModule(
+        argument_spec, required_if=required_if, supports_check_mode=True
+    )
+
+    if not HAS_PURESTORAGE:
+        module.fail_json(msg="py-pure-client sdk is required for this module")
+
+    array = get_array(module)
+    resource_type = module.params["resource_type"]
+    check_api_version(
+        array,
+        RESOURCES[resource_type][1],
+        module,
+        "Tagging a {0}".format(resource_type.replace("_", " ")),
+    )
+
+    current = read_tags(module, array)
+
+    if module.params["state"] == "present":
+        apply_tags(module, array, current)
+    else:
+        remove_tags(module, array, current)
+
+    module.exit_json(changed=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/purefa_tags.py
+++ b/plugins/modules/purefa_tags.py
@@ -23,9 +23,9 @@ description:
 - Add, change and remove key/value tags on Everpure FlashArray resources.
 - One module covers every taggable resource type. Which type is being tagged is
   given by I(resource_type), and the resource itself by I(name).
-- Volumes are not included. They have their own module,
-  M(everpure.flasharray.purefa_volume_tags), which also exposes the volume-only
-  behaviour of I(copyable).
+- Volumes are covered here too. The older
+  M(everpure.flasharray.purefa_volume_tags) still works and is unchanged, but
+  this module supersedes it and is the one to use from now on.
 author:
 - Everpure Ansible Team (@sdodsley) <pure-ansible-team@everpuredata.com>
 options:
@@ -46,6 +46,7 @@ options:
     - protection_group
     - protection_group_snapshot
     - realm
+    - volume
     - volume_group
     - volume_snapshot
     - workload
@@ -83,8 +84,8 @@ options:
     - Whether the tag is inherited by copies of the resource.
     - Only the volume family honours this. The array accepts it for the other
       resource types and silently stores C(true) regardless, so it is only
-      compared, and only reported as a change, for C(volume_group) and
-      C(volume_snapshot).
+      compared, and only reported as a change, for C(volume),
+      C(volume_group) and C(volume_snapshot).
     - Omit it to let the array use its own default.
     type: bool
   state:
@@ -104,9 +105,10 @@ extends_documentation_fragment:
 - everpure.flasharray.everpure.fa
 notes:
 - The minimum Purity//FA REST version depends on I(resource_type)
-  - C(volume_snapshot) from 2.2, C(array), C(host) and C(host_group) from 2.34,
-  C(pod), C(protection_group) and C(volume_group) from 2.39, C(workload) from
-  2.40, C(realm) from 2.41 and C(protection_group_snapshot) from 2.44.
+  - C(volume) and C(volume_snapshot) from 2.2, C(array), C(host) and
+  C(host_group) from 2.34, C(pod), C(protection_group) and C(volume_group) from
+  2.39, C(workload) from 2.40, C(realm) from 2.41 and
+  C(protection_group_snapshot) from 2.44.
 - Tagging a resource that does not exist fails with the array's own message,
   which names the resource type.
 - Cloud provider tags, which propagate to the cloud a Cloud Block Store
@@ -150,6 +152,16 @@ EXAMPLES = r"""
     namespace: reporting
     kvp:
     - tier:gold
+    fa_url: 10.10.10.2
+    api_token: e31060a7-21fc-e277-6240-25983c6c4592
+
+- name: Tag a volume, replacing what purefa_volume_tags did
+  everpure.flasharray.purefa_tags:
+    resource_type: volume
+    name: foo
+    kvp:
+    - env:production
+    copyable: true
     fa_url: 10.10.10.2
     api_token: e31060a7-21fc-e277-6240-25983c6c4592
 
@@ -200,6 +212,7 @@ RESOURCES = {
     "protection_group": ("protection_groups", "2.39"),
     "protection_group_snapshot": ("protection_group_snapshots", "2.44"),
     "realm": ("realms", "2.41"),
+    "volume": ("volumes", "2.2"),
     "volume_group": ("volume_groups", "2.39"),
     "volume_snapshot": ("volume_snapshots", "2.2"),
     "workload": ("workloads", "2.40"),
@@ -212,7 +225,7 @@ SINGLETON = "array"
 # Only the volume family stores copyable as given. The others accept the field
 # and report true whatever was sent, so comparing it there would make a play
 # that sets copyable=false report a change on every run.
-COPYABLE_TYPES = ("volume_group", "volume_snapshot")
+COPYABLE_TYPES = ("volume", "volume_group", "volume_snapshot")
 
 
 def _api_name(module):

--- a/plugins/modules/purefa_volume_tags.py
+++ b/plugins/modules/purefa_volume_tags.py
@@ -46,13 +46,17 @@ options:
     - Separate the key from the value using a colon (:) only.
     - All items in list will use I(namespace) and I(copyable) settings.
     - See examples for exact formatting requirements
+    - With I(state=absent) and no I(tag), the keys of these pairs are the tags
+      removed and their values are ignored.
     type: list
     elements: str
   tag:
     description:
-    - List of volume tags to be deleted from a volume
+    - List of tag keys to remove from the volume, for use with I(state=absent).
+    - Takes precedence over the keys in I(kvp).
     type: list
     elements: str
+    aliases: [ keys ]
     version_added: "1.38.0"
   state:
     description:
@@ -120,6 +124,7 @@ from ansible_collections.everpure.flasharray.plugins.module_utils.purefa import 
     purefa_argument_spec,
 )
 from ansible_collections.everpure.flasharray.plugins.module_utils.api_helpers import (
+    delete_with_context,
     get_with_context,
     check_response,
 )
@@ -227,33 +232,36 @@ def update_tags(module, array, current_tags):
 
 
 def delete_tags(module, array, current_tags):
-    """Delete Tags"""
-    changed = False
-    now_tags = []
-    old_tags = []
-    for tag in current_tags:
-        now_tags.append(tag.key)
-    for old_tag in module.params["kvp"]:
-        old_tags.append((old_tag,))
-    del_tags = list(set(old_tags) & set(now_tags))
-    if del_tags:
-        changed = True
-        if not module.check_mode:
-            for tag in del_tags:
-                res = get_with_context(
-                    array,
-                    "delete_volumes_tags",
-                    CONTEXT_API_VERSION,
-                    module,
-                    resource_names=[module.params["name"]],
-                    keys=[tag],
-                    namespaces=[module.params["namespace"]],
-                )
-                check_response(
-                    res,
-                    module,
-                    f"Failed to remove tag {tag} from volume {module.params['name']}",
-                )
+    """Delete Tags
+
+    Removal works on keys. I(tag) names them directly; failing that the keys of
+    I(kvp) are used and their values ignored, so the same list that created the
+    tags can remove them.
+    """
+    if module.params["tag"]:
+        requested = list(module.params["tag"])
+    else:
+        requested = [pair.split(":")[0] for pair in module.params["kvp"] or []]
+    if not requested:
+        module.fail_json(msg="tag or kvp is required to remove volume tags")
+    held = {tag.key for tag in current_tags}
+    doomed = sorted(set(requested) & held)
+    changed = bool(doomed)
+    if doomed and not module.check_mode:
+        res = delete_with_context(
+            array,
+            "delete_volumes_tags",
+            CONTEXT_API_VERSION,
+            module,
+            resource_names=[module.params["name"]],
+            keys=doomed,
+            namespaces=[module.params["namespace"]],
+        )
+        check_response(
+            res,
+            module,
+            f"Failed to remove tags from volume {module.params['name']}",
+        )
     module.exit_json(changed=changed)
 
 
@@ -266,7 +274,7 @@ def main():
             namespace=dict(type="str", default="default"),
             state=dict(type="str", default="present", choices=["absent", "present"]),
             kvp=dict(type="list", elements="str"),
-            tag=dict(type="list", elements="str"),
+            tag=dict(type="list", elements="str", aliases=["keys"]),
             context=dict(type="str", default=""),
         )
     )

--- a/plugins/modules/purefa_volume_tags.py
+++ b/plugins/modules/purefa_volume_tags.py
@@ -21,6 +21,10 @@ version_added: '1.0.0'
 short_description:  Manage volume tags on Everpure FlashArrays
 description:
 - Manage volume tags for volumes on Everpure FlashArray.
+- This module is superseded by M(everpure.flasharray.purefa_tags), which
+  manages tags on volumes and on every other taggable resource. Use that
+  module from now on. This one still works and will be deprecated in a future
+  release.
 - Requires a minimum of Purity 6.0.0
 author:
 - Everpure Ansible Team (@sdodsley) <pure-ansible-team@everpuredata.com>
@@ -280,6 +284,13 @@ def main():
     )
 
     module = AnsibleModule(argument_spec, supports_check_mode=True)
+
+    module.warn(
+        "purefa_volume_tags is superseded by purefa_tags, which manages tags "
+        "on volumes and every other taggable resource. Use "
+        "purefa_tags with resource_type: volume from now on. This module still "
+        "works and will be deprecated in a future release."
+    )
 
     state = module.params["state"]
     array = get_array(module)

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -115,6 +115,7 @@ plugins/modules/purefa_sso.py import-2.7
 plugins/modules/purefa_subnet.py import-2.7
 plugins/modules/purefa_syslog.py import-2.7
 plugins/modules/purefa_syslog_settings.py import-2.7
+plugins/modules/purefa_tags.py import-2.7
 plugins/modules/purefa_tgroup.py import-2.7
 plugins/modules/purefa_timeout.py import-2.7
 plugins/modules/purefa_token.py import-2.7

--- a/tests/unit/plugins/module_utils/test_api_helpers.py
+++ b/tests/unit/plugins/module_utils/test_api_helpers.py
@@ -63,6 +63,7 @@ from plugins.module_utils.api_helpers import (
     check_api_version,
     get_local_array_name,
     get_with_context,
+    put_with_context,
     wait_for,
 )
 
@@ -618,3 +619,46 @@ class TestWaitForSkipInCheckMode:
         )
 
         assert result is finished
+
+
+class TestPutWithContext:
+    """Tests for put_with_context function.
+
+    It is an alias for get_with_context, so what matters is that a PUT method
+    is reached and that context is still applied.
+    """
+
+    def test_calls_put_method(self, mock_module, mock_array):
+        """Test the named put method is called with the arguments given."""
+        mock_array.put_hosts_tags_batch = Mock()
+
+        put_with_context(
+            mock_array,
+            "put_hosts_tags_batch",
+            "2.38",
+            mock_module,
+            resource_names=["host1"],
+            tag=["a-tag"],
+        )
+
+        mock_array.put_hosts_tags_batch.assert_called_once_with(
+            resource_names=["host1"], tag=["a-tag"]
+        )
+
+    def test_adds_context_when_supported(self, mock_module):
+        """Test context_names is added just as it is for the other verbs."""
+        array = Mock(spec=["get_rest_version", "put_hosts_tags_batch"])
+        array.get_rest_version.return_value = "2.38"
+        mock_module.params["context"] = "pod1"
+
+        put_with_context(
+            array,
+            "put_hosts_tags_batch",
+            "2.38",
+            mock_module,
+            resource_names=["host1"],
+        )
+
+        array.put_hosts_tags_batch.assert_called_once_with(
+            resource_names=["host1"], context_names=["pod1"]
+        )

--- a/tests/unit/plugins/modules/test_purefa_tags.py
+++ b/tests/unit/plugins/modules/test_purefa_tags.py
@@ -93,9 +93,9 @@ class TestResourceMap:
         assert len(versions) > 1
         assert "2.2" in versions and "2.44" in versions
 
-    def test_volumes_are_not_included(self):
-        """Volumes keep their own module, so they must not appear here"""
-        assert "volume" not in RESOURCES
+    def test_volumes_are_included(self):
+        """Volumes are covered here, superseding purefa_volume_tags"""
+        assert RESOURCES["volume"] == ("volumes", "2.2")
 
     def test_api_name_is_the_plural_api_form(self):
         assert _api_name(make_module(resource_type="host_group")) == "host_groups"
@@ -472,3 +472,32 @@ class TestMain:
         mod.main()
 
         assert mock_api.call_args[0][1] == "2.44"
+
+
+class TestVolumeSupport:
+    """Volumes came in to supersede purefa_volume_tags"""
+
+    def test_volume_uses_the_batch_put_like_the_others(self):
+        """Only the array is the odd one out, volumes are not"""
+        module = make_module(resource_type="volume", name="vol1")
+
+        assert _api_name(module) == "volumes"
+        assert _resource_args(module) == {"resource_names": ["vol1"]}
+
+    def test_copyable_is_compared_for_a_volume(self):
+        """copyable is honoured on volumes, so a difference is a change"""
+        module = make_module(resource_type="volume", name="vol1", copyable=False)
+
+        assert _compares_copyable(module) is True
+
+    @patch("plugins.modules.purefa_tags._write_tags")
+    def test_volume_copyable_difference_is_written(self, mock_write):
+        module = make_module(
+            resource_type="volume", name="vol1", kvp=["a:1"], copyable=False
+        )
+        array = Mock()
+
+        apply_tags(module, array, [make_tag("a", "1", copyable=True)])
+
+        mock_write.assert_called_once_with(module, array, [("a", "1")])
+        module.exit_json.assert_called_once_with(changed=True)

--- a/tests/unit/plugins/modules/test_purefa_tags.py
+++ b/tests/unit/plugins/modules/test_purefa_tags.py
@@ -1,0 +1,474 @@
+# Copyright: (c) 2026, Everpure Ansible Team <pure-ansible-team@everpuredata.com>
+# GNU General Public License v3.0+ (see COPYING.GPLv3 or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for purefa_tags module."""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import sys
+from unittest.mock import Mock, MagicMock, patch
+
+import pytest
+
+# Mock external dependencies before importing module
+sys.modules["grp"] = MagicMock()
+sys.modules["pwd"] = MagicMock()
+sys.modules["fcntl"] = MagicMock()
+sys.modules["ansible"] = MagicMock()
+sys.modules["ansible.module_utils"] = MagicMock()
+sys.modules["ansible.module_utils.basic"] = MagicMock()
+sys.modules["pypureclient"] = MagicMock()
+sys.modules["pypureclient.flasharray"] = MagicMock()
+sys.modules["ansible_collections"] = MagicMock()
+sys.modules["ansible_collections.everpure"] = MagicMock()
+sys.modules["ansible_collections.everpure.flasharray"] = MagicMock()
+sys.modules["ansible_collections.everpure.flasharray.plugins"] = MagicMock()
+sys.modules["ansible_collections.everpure.flasharray.plugins.module_utils"] = (
+    MagicMock()
+)
+sys.modules["ansible_collections.everpure.flasharray.plugins.module_utils.purefa"] = (
+    MagicMock()
+)
+sys.modules[
+    "ansible_collections.everpure.flasharray.plugins.module_utils.api_helpers"
+] = MagicMock()
+
+from plugins.modules.purefa_tags import (
+    RESOURCES,
+    apply_tags,
+    parse_kvp,
+    read_tags,
+    remove_tags,
+    _api_name,
+    _compares_copyable,
+    _resource_args,
+)
+
+
+def make_module(**params):
+    """An AnsibleModule stand-in whose fail_json raises, as the real one does"""
+    module = Mock()
+    module.check_mode = False
+    base = {
+        "resource_type": "host",
+        "name": "host1",
+        "namespace": "default",
+        "kvp": None,
+        "keys": None,
+        "copyable": None,
+        "state": "present",
+        "context": "",
+    }
+    base.update(params)
+    module.params = base
+    module.fail_json.side_effect = SystemExit(1)
+    return module
+
+
+def make_tag(key, value, copyable=True):
+    tag = Mock()
+    tag.key = key
+    tag.value = value
+    tag.copyable = copyable
+    return tag
+
+
+class TestResourceMap:
+    """The map is the module's whole reason for existing"""
+
+    def test_every_resource_has_an_api_name_and_version(self):
+        for resource_type, (api_name, version) in RESOURCES.items():
+            assert api_name, resource_type
+            assert version.startswith("2."), resource_type
+
+    def test_versions_are_per_resource_not_uniform(self):
+        """Test the map really does carry different floors
+
+        A single version for every type would have been wrong - the endpoints
+        arrived across 2.2 to 2.44.
+        """
+        versions = {version for _api, version in RESOURCES.values()}
+        assert len(versions) > 1
+        assert "2.2" in versions and "2.44" in versions
+
+    def test_volumes_are_not_included(self):
+        """Volumes keep their own module, so they must not appear here"""
+        assert "volume" not in RESOURCES
+
+    def test_api_name_is_the_plural_api_form(self):
+        assert _api_name(make_module(resource_type="host_group")) == "host_groups"
+        assert _api_name(make_module(resource_type="array")) == "arrays"
+
+
+class TestResourceArgs:
+    """Test cases for _resource_args function"""
+
+    def test_named_resource_passes_its_name(self):
+        assert _resource_args(make_module()) == {"resource_names": ["host1"]}
+
+    def test_array_passes_no_name(self):
+        """The array is a singleton, so its endpoints take no resource name"""
+        module = make_module(resource_type="array", name=None)
+
+        assert _resource_args(module) == {}
+
+
+class TestComparesCopyable:
+    """copyable is only honoured by the volume family"""
+
+    def test_not_compared_when_unset(self):
+        assert _compares_copyable(make_module(resource_type="volume_group")) is False
+
+    def test_compared_for_volume_group(self):
+        module = make_module(resource_type="volume_group", copyable=False)
+
+        assert _compares_copyable(module) is True
+
+    def test_not_compared_for_host(self):
+        """Test copyable is ignored for a host
+
+        The array stores true whatever is sent, so comparing it would report a
+        change on every run.
+        """
+        module = make_module(resource_type="host", copyable=False)
+
+        assert _compares_copyable(module) is False
+
+
+class TestParseKvp:
+    """Test cases for parse_kvp function"""
+
+    def test_splits_on_the_first_colon_only(self):
+        """Test a value may itself contain colons"""
+        module = make_module(kvp=["url:https://example.com:8443"])
+
+        assert parse_kvp(module) == [("url", "https://example.com:8443")]
+
+    def test_multiple_pairs(self):
+        module = make_module(kvp=["a:1", "b:2"])
+
+        assert parse_kvp(module) == [("a", "1"), ("b", "2")]
+
+    def test_empty_value_is_allowed(self):
+        module = make_module(kvp=["a:"])
+
+        assert parse_kvp(module) == [("a", "")]
+
+    def test_missing_colon_fails(self):
+        module = make_module(kvp=["nocolon"])
+
+        with pytest.raises(SystemExit):
+            parse_kvp(module)
+
+        assert "key:value form" in module.fail_json.call_args[1]["msg"]
+
+    def test_empty_key_fails(self):
+        module = make_module(kvp=[":value"])
+
+        with pytest.raises(SystemExit):
+            parse_kvp(module)
+
+        assert "empty key" in module.fail_json.call_args[1]["msg"]
+
+    def test_no_kvp_is_an_empty_list(self):
+        assert parse_kvp(make_module()) == []
+
+
+class TestReadTags:
+    """Test cases for read_tags function"""
+
+    @patch("plugins.modules.purefa_tags.get_with_context")
+    def test_read_always_sends_the_namespace(self, mock_get):
+        """Test the namespace is part of every read
+
+        A read that leaves it out comes back with the default namespace only,
+        which would hide tags in any other namespace.
+        """
+        module = make_module(namespace="other")
+        mock_get.return_value = Mock(status_code=200, items=[make_tag("a", "1")])
+
+        read_tags(module, Mock())
+
+        kwargs = mock_get.call_args[1]
+        assert kwargs["namespaces"] == ["other"]
+        assert kwargs["resource_names"] == ["host1"]
+        assert mock_get.call_args[0][1] == "get_hosts_tags"
+
+    @patch("plugins.modules.purefa_tags.get_with_context")
+    def test_read_for_the_array_sends_no_resource_name(self, mock_get):
+        module = make_module(resource_type="array", name=None)
+        mock_get.return_value = Mock(status_code=200, items=[])
+
+        read_tags(module, Mock())
+
+        assert "resource_names" not in mock_get.call_args[1]
+        assert mock_get.call_args[0][1] == "get_arrays_tags"
+
+    @patch("plugins.modules.purefa_tags.check_response")
+    @patch("plugins.modules.purefa_tags.get_with_context")
+    def test_read_failure_is_surfaced(self, mock_get, mock_check):
+        """Test a bad read goes through check_response
+
+        Tagging something that does not exist fails here, with the array's own
+        message naming the resource type.
+        """
+        module = make_module()
+        mock_get.return_value = Mock(status_code=400, items=[])
+
+        read_tags(module, Mock())
+
+        mock_check.assert_called_once()
+
+
+class TestApplyTags:
+    """Test cases for apply_tags function"""
+
+    @patch("plugins.modules.purefa_tags._write_tags")
+    def test_requires_kvp(self, mock_write):
+        module = make_module()
+
+        with pytest.raises(SystemExit):
+            apply_tags(module, Mock(), [])
+
+        assert "kvp is required" in module.fail_json.call_args[1]["msg"]
+        mock_write.assert_not_called()
+
+    @patch("plugins.modules.purefa_tags._write_tags")
+    def test_writes_a_missing_tag(self, mock_write):
+        module = make_module(kvp=["a:1"])
+        array = Mock()
+
+        apply_tags(module, array, [])
+
+        mock_write.assert_called_once_with(module, array, [("a", "1")])
+        module.exit_json.assert_called_once_with(changed=True)
+
+    @patch("plugins.modules.purefa_tags._write_tags")
+    def test_matching_tag_is_no_change(self, mock_write):
+        """Test a put is not issued when nothing differs
+
+        The array accepts a put whether or not anything changes, so the
+        difference has to be worked out in the module.
+        """
+        module = make_module(kvp=["a:1"])
+
+        apply_tags(module, Mock(), [make_tag("a", "1")])
+
+        mock_write.assert_not_called()
+        module.exit_json.assert_called_once_with(changed=False)
+
+    @patch("plugins.modules.purefa_tags._write_tags")
+    def test_changed_value_is_written(self, mock_write):
+        module = make_module(kvp=["a:2"])
+        array = Mock()
+
+        apply_tags(module, array, [make_tag("a", "1")])
+
+        mock_write.assert_called_once_with(module, array, [("a", "2")])
+        module.exit_json.assert_called_once_with(changed=True)
+
+    @patch("plugins.modules.purefa_tags._write_tags")
+    def test_only_the_differing_pairs_are_written(self, mock_write):
+        module = make_module(kvp=["a:1", "b:9"])
+        array = Mock()
+
+        apply_tags(module, array, [make_tag("a", "1"), make_tag("b", "2")])
+
+        mock_write.assert_called_once_with(module, array, [("b", "9")])
+
+    @patch("plugins.modules.purefa_tags._write_tags")
+    def test_copyable_difference_counts_for_a_volume_group(self, mock_write):
+        module = make_module(
+            resource_type="volume_group", name="vg1", kvp=["a:1"], copyable=False
+        )
+        array = Mock()
+
+        apply_tags(module, array, [make_tag("a", "1", copyable=True)])
+
+        mock_write.assert_called_once_with(module, array, [("a", "1")])
+        module.exit_json.assert_called_once_with(changed=True)
+
+    @patch("plugins.modules.purefa_tags._write_tags")
+    def test_copyable_difference_ignored_for_a_host(self, mock_write):
+        """Test an ignored copyable does not produce a change every run"""
+        module = make_module(kvp=["a:1"], copyable=False)
+
+        apply_tags(module, Mock(), [make_tag("a", "1", copyable=True)])
+
+        mock_write.assert_not_called()
+        module.exit_json.assert_called_once_with(changed=False)
+
+    @patch("plugins.modules.purefa_tags._write_tags")
+    def test_check_mode_predicts_without_writing(self, mock_write):
+        module = make_module(kvp=["a:1"])
+        module.check_mode = True
+
+        apply_tags(module, Mock(), [])
+
+        mock_write.assert_not_called()
+        module.exit_json.assert_called_once_with(changed=True)
+
+
+class TestRemoveTags:
+    """Test cases for remove_tags function"""
+
+    @patch("plugins.modules.purefa_tags.delete_with_context")
+    def test_requires_keys_or_kvp(self, mock_delete):
+        module = make_module(state="absent")
+
+        with pytest.raises(SystemExit):
+            remove_tags(module, Mock(), [])
+
+        assert "keys or kvp is required" in module.fail_json.call_args[1]["msg"]
+        mock_delete.assert_not_called()
+
+    @patch("plugins.modules.purefa_tags.check_response")
+    @patch("plugins.modules.purefa_tags.delete_with_context")
+    def test_removes_only_what_is_there(self, mock_delete, mock_check):
+        module = make_module(state="absent", keys=["a", "nosuch"])
+        mock_delete.return_value = Mock(status_code=200)
+
+        remove_tags(module, Mock(), [make_tag("a", "1")])
+
+        assert mock_delete.call_args[1]["keys"] == ["a"]
+        assert mock_delete.call_args[1]["namespaces"] == ["default"]
+        module.exit_json.assert_called_once_with(changed=True)
+
+    @patch("plugins.modules.purefa_tags.delete_with_context")
+    def test_nothing_to_remove_is_no_change(self, mock_delete):
+        """Test a delete is not issued for a key the resource does not have
+
+        The array accepts a delete of a missing key, so the module has to
+        decide for itself.
+        """
+        module = make_module(state="absent", keys=["nosuch"])
+
+        remove_tags(module, Mock(), [make_tag("a", "1")])
+
+        mock_delete.assert_not_called()
+        module.exit_json.assert_called_once_with(changed=False)
+
+    @patch("plugins.modules.purefa_tags.check_response")
+    @patch("plugins.modules.purefa_tags.delete_with_context")
+    def test_kvp_keys_are_used_when_keys_is_absent(self, mock_delete, mock_check):
+        """Test removal by kvp uses the keys and ignores the values
+
+        purefa_volume_tags compares 1-tuples against strings here and so never
+        removes anything; this asserts the working behaviour.
+        """
+        module = make_module(state="absent", kvp=["a:whatever"])
+        mock_delete.return_value = Mock(status_code=200)
+
+        remove_tags(module, Mock(), [make_tag("a", "1")])
+
+        assert mock_delete.call_args[1]["keys"] == ["a"]
+        module.exit_json.assert_called_once_with(changed=True)
+
+    @patch("plugins.modules.purefa_tags.check_response")
+    @patch("plugins.modules.purefa_tags.delete_with_context")
+    def test_keys_wins_over_kvp(self, mock_delete, mock_check):
+        module = make_module(state="absent", keys=["b"], kvp=["a:1"])
+        mock_delete.return_value = Mock(status_code=200)
+
+        remove_tags(module, Mock(), [make_tag("a", "1"), make_tag("b", "2")])
+
+        assert mock_delete.call_args[1]["keys"] == ["b"]
+
+    @patch("plugins.modules.purefa_tags.delete_with_context")
+    def test_check_mode_predicts_without_deleting(self, mock_delete):
+        module = make_module(state="absent", keys=["a"])
+        module.check_mode = True
+
+        remove_tags(module, Mock(), [make_tag("a", "1")])
+
+        mock_delete.assert_not_called()
+        module.exit_json.assert_called_once_with(changed=True)
+
+
+class TestMain:
+    """Test cases for the main dispatch"""
+
+    @patch("plugins.modules.purefa_tags.get_array")
+    @patch("plugins.modules.purefa_tags.AnsibleModule")
+    def test_main_no_purestorage_sdk(self, mock_am, mock_ga):
+        import plugins.modules.purefa_tags as mod
+
+        original = mod.HAS_PURESTORAGE
+        mod.HAS_PURESTORAGE = False
+        module = make_module()
+        mock_am.return_value = module
+        try:
+            with pytest.raises(SystemExit):
+                mod.main()
+            assert "sdk is required" in module.fail_json.call_args[1]["msg"]
+        finally:
+            mod.HAS_PURESTORAGE = original
+
+    @patch("plugins.modules.purefa_tags.apply_tags")
+    @patch("plugins.modules.purefa_tags.read_tags")
+    @patch("plugins.modules.purefa_tags.check_api_version")
+    @patch("plugins.modules.purefa_tags.get_array")
+    @patch("plugins.modules.purefa_tags.AnsibleModule")
+    def test_main_present_applies(
+        self, mock_am, mock_ga, mock_api, mock_read, mock_apply
+    ):
+        import plugins.modules.purefa_tags as mod
+
+        module = make_module(kvp=["a:1"])
+        mock_am.return_value = module
+        array = Mock()
+        mock_ga.return_value = array
+        current = [make_tag("a", "1")]
+        mock_read.return_value = current
+
+        mod.main()
+
+        mock_apply.assert_called_once_with(module, array, current)
+
+    @patch("plugins.modules.purefa_tags.remove_tags")
+    @patch("plugins.modules.purefa_tags.read_tags")
+    @patch("plugins.modules.purefa_tags.check_api_version")
+    @patch("plugins.modules.purefa_tags.get_array")
+    @patch("plugins.modules.purefa_tags.AnsibleModule")
+    def test_main_absent_removes(
+        self, mock_am, mock_ga, mock_api, mock_read, mock_remove
+    ):
+        import plugins.modules.purefa_tags as mod
+
+        module = make_module(state="absent", keys=["a"])
+        mock_am.return_value = module
+        array = Mock()
+        mock_ga.return_value = array
+        mock_read.return_value = []
+
+        mod.main()
+
+        mock_remove.assert_called_once_with(module, array, [])
+
+    @patch("plugins.modules.purefa_tags.apply_tags")
+    @patch("plugins.modules.purefa_tags.read_tags")
+    @patch("plugins.modules.purefa_tags.check_api_version")
+    @patch("plugins.modules.purefa_tags.get_array")
+    @patch("plugins.modules.purefa_tags.AnsibleModule")
+    def test_main_checks_the_version_for_the_requested_type(
+        self, mock_am, mock_ga, mock_api, mock_read, mock_apply
+    ):
+        """Test the guardrail is the version for that resource type
+
+        protection_group_snapshot tags arrived in 2.44, far later than the
+        2.2 of volume snapshots.
+        """
+        import plugins.modules.purefa_tags as mod
+
+        module = make_module(
+            resource_type="protection_group_snapshot", name="pg.1", kvp=["a:1"]
+        )
+        mock_am.return_value = module
+        mock_ga.return_value = Mock()
+        mock_read.return_value = []
+
+        mod.main()
+
+        assert mock_api.call_args[0][1] == "2.44"

--- a/tests/unit/plugins/modules/test_purefa_volume_tags.py
+++ b/tests/unit/plugins/modules/test_purefa_volume_tags.py
@@ -243,23 +243,115 @@ class TestUpdateTags:
 class TestDeleteTags:
     """Tests for delete_tags function"""
 
-    def test_delete_tags_no_match(self):
-        """Test delete_tags when tags don't match"""
+    @staticmethod
+    def _module(**params):
         mock_module = Mock()
-        mock_module.params = {
+        base = {
             "name": "test-vol",
             "context": "",
-            "kvp": ["nonexistent"],
+            "kvp": None,
+            "tag": None,
             "namespace": "default",
         }
+        base.update(params)
+        mock_module.params = base
         mock_module.check_mode = False
-        mock_array = Mock()
+        mock_module.fail_json.side_effect = SystemExit(1)
+        return mock_module
 
-        # Current tags don't include the tag to delete
-        mock_tag = Mock()
-        mock_tag.key = "env"
-        current_tags = [mock_tag]
+    @staticmethod
+    def _tags(*keys):
+        out = []
+        for key in keys:
+            tag = Mock()
+            tag.key = key
+            out.append(tag)
+        return out
 
-        delete_tags(mock_module, mock_array, current_tags)
+    def test_delete_tags_no_match(self):
+        """Test delete_tags when tags don't match"""
+        mock_module = self._module(kvp=["nonexistent"])
+
+        delete_tags(mock_module, Mock(), self._tags("env"))
 
         mock_module.exit_json.assert_called_once_with(changed=False)
+
+    @patch("plugins.modules.purefa_volume_tags.check_response")
+    @patch("plugins.modules.purefa_volume_tags.delete_with_context")
+    def test_delete_tags_by_kvp_key(self, mock_delete, mock_check):
+        """Test the keys of kvp remove the tags, values ignored
+
+        The old code compared one-element tuples against key strings, so this
+        never matched and nothing was ever deleted.
+        """
+        mock_module = self._module(kvp=["env:whatever"])
+        mock_delete.return_value = Mock(status_code=200)
+
+        delete_tags(mock_module, Mock(), self._tags("env", "owner"))
+
+        assert mock_delete.call_args[1]["keys"] == ["env"]
+        assert mock_delete.call_args[1]["namespaces"] == ["default"]
+        mock_module.exit_json.assert_called_once_with(changed=True)
+
+    @patch("plugins.modules.purefa_volume_tags.check_response")
+    @patch("plugins.modules.purefa_volume_tags.delete_with_context")
+    def test_delete_tags_by_tag_option(self, mock_delete, mock_check):
+        """Test the documented tag option removes tags
+
+        It was declared and documented but never read, so it did nothing. With
+        kvp left unset the old code also raised TypeError iterating None.
+        """
+        mock_module = self._module(tag=["env", "owner"])
+        mock_delete.return_value = Mock(status_code=200)
+
+        delete_tags(mock_module, Mock(), self._tags("env", "owner", "keep"))
+
+        assert mock_delete.call_args[1]["keys"] == ["env", "owner"]
+        mock_module.exit_json.assert_called_once_with(changed=True)
+
+    @patch("plugins.modules.purefa_volume_tags.check_response")
+    @patch("plugins.modules.purefa_volume_tags.delete_with_context")
+    def test_delete_tags_only_removes_what_is_there(self, mock_delete, mock_check):
+        """Test a key the volume does not carry is not sent for deletion"""
+        mock_module = self._module(tag=["env", "nosuch"])
+        mock_delete.return_value = Mock(status_code=200)
+
+        delete_tags(mock_module, Mock(), self._tags("env"))
+
+        assert mock_delete.call_args[1]["keys"] == ["env"]
+        mock_module.exit_json.assert_called_once_with(changed=True)
+
+    @patch("plugins.modules.purefa_volume_tags.delete_with_context")
+    def test_delete_tags_tag_wins_over_kvp(self, mock_delete):
+        """Test tag takes precedence over the keys in kvp"""
+        mock_module = self._module(tag=["owner"], kvp=["env:x"])
+        mock_delete.return_value = Mock(status_code=200)
+
+        with patch("plugins.modules.purefa_volume_tags.check_response"):
+            delete_tags(mock_module, Mock(), self._tags("env", "owner"))
+
+        assert mock_delete.call_args[1]["keys"] == ["owner"]
+
+    @patch("plugins.modules.purefa_volume_tags.delete_with_context")
+    def test_delete_tags_check_mode(self, mock_delete):
+        """Test check mode predicts the removal without making it"""
+        mock_module = self._module(tag=["env"])
+        mock_module.check_mode = True
+
+        delete_tags(mock_module, Mock(), self._tags("env"))
+
+        mock_delete.assert_not_called()
+        mock_module.exit_json.assert_called_once_with(changed=True)
+
+    @patch("plugins.modules.purefa_volume_tags.delete_with_context")
+    def test_delete_tags_nothing_requested_fails(self, mock_delete):
+        """Test state=absent with neither option says so"""
+        import pytest
+
+        mock_module = self._module()
+
+        with pytest.raises(SystemExit):
+            delete_tags(mock_module, Mock(), self._tags("env"))
+
+        assert "tag or kvp is required" in mock_module.fail_json.call_args[1]["msg"]
+        mock_delete.assert_not_called()


### PR DESCRIPTION
##### SUMMARY

`purefa_volume_tags` was the only tag module, and it covers volumes only. Ten
other resource types accept tags and none could be reached. One module with a
`resource_type` option closes all of them.

Covered: `array`, `host`, `host_group`, `pod`, `protection_group`,
`protection_group_snapshot`, `realm`, `volume`, `volume_group`,
`volume_snapshot` and `workload` — eleven types, volumes included.

`purefa_volume_tags` keeps working and now **warns on every run** that it is
superseded, naming what to use instead. The overlap is deliberate for now, with
that module to be deprecated in a future release. Its broken removal path is
fixed here too, below.

##### The parity audit said these endpoints were identical in shape. They are not

Checking each one changed the design:

| Finding | Consequence |
| --- | --- |
| The tag endpoints arrived across a wide range — **2.2** for volume snapshots through **2.44** for protection group snapshots | the version guardrail is **per resource type**, not one floor for the module |
| **The array is a singleton** — its endpoints take no resource name, and its write is `put_arrays_tags`, not the `_tags_batch` form every other type uses | `name` is required for every type except `array` |
| A put is accepted whether or not anything changes, and so is a delete of a key that is not there — **neither reports what it did** | the module computes the difference itself and writes only what differs |
| **A read that omits the namespace returns the default namespace only** | the namespace is sent on every read, or tags elsewhere are invisible and look absent |
| **`copyable` is honoured for the volume family — `volume`, `volume_group`, `volume_snapshot` — but silently stored as `true` for the others** | it is compared only where it is honoured. Verified by setting `false` on a host, a volume and a volume group and reading all three back |

That last one matters: comparing `copyable` everywhere would make a play setting
`copyable: false` on a host report a change on **every** run. The module documents
that the array ignores it for those types rather than pretending otherwise.

A key/value pair splits on the **first colon only**, so a value may contain
colons — a URL, for instance.

##### Also: `put_with_context`

`api_helpers` had `get`, `post`, `patch` and `delete` aliases but no `put`, so PUT
endpoints were reached through `get_with_context` — which reads as a GET at every
call site. This adds the missing alias, identical to its siblings, with two unit
tests. There are 14 PUT endpoints in the SDK, so it will be needed again.

##### ISSUE TYPE

- New Module Pull Request

##### COMPONENT NAME

purefa_tags

##### ADDITIONAL INFORMATION

Validated on hardware, every action run twice:

```
TASK [Host tags must predict, change once, then report no change] ***  ok
TASK [A changed value must change once then settle] ***  ok
TASK [Only the first colon separates key from value] ***  ok
TASK [Refuse a pair that is not key:value] ***  ok
TASK [A namespaced tag is a separate tag] ***  ok
TASK [Removal must change once then report no change] ***  ok
TASK [Removing by kvp key must work regardless of the value given] ***  ok
TASK [Every resource type must behave the same way] ***  ok
TASK [copyable must be honoured and settle for a volume group] ***  ok
TASK [A copyable change is a change where the array honours it] ***  ok
TASK [An ignored copyable must not cause a change every run] ***  ok
TASK [The array takes tags with no name and stays idempotent] ***  ok
TASK [A named type without a name must fail] ***  ok
TASK [The array's own message must come through] ***  ok

PLAY RECAP
localhost : ok=54  changed=22  unreachable=0  failed=0
```

The play created its own host, host group, volume group and protection group and
removed them. The only shared object it touched is the array itself, whose tag it
added and then removed — `get_arrays_tags` was empty before the run and empty
after, checked separately.

72 unit tests (including the two for `put_with_context`) cover the resource map,
the array's no-name special case, `copyable` compared for a volume group and
ignored for a host, the first-colon-only split with its failure cases, the
namespace always being sent, write-only-what-differs, delete-only-what-exists,
removal by `keys` and by `kvp` keys, check mode on both write paths, and that the
guardrail checked is the one for the requested type.

`ansible-test sanity --local` passes. Sanity caught one thing worth noting: the
`keys` option needed an explicit `no_log=False`, since validate-modules flags any
option whose name looks like a secret.

##### Also fixes purefa_volume_tags, which could not remove a tag at all

Found while reading it for its conventions. `state: absent` was broken by both
routes, reproduced against upstream master on a volume carrying `env` and
`owner`:

```
remove by tag : changed=False failed=True msg=MODULE FAILURE
remove by kvp : changed=False failed=False msg=none
tags left     : env, owner
```

Three defects, all in `delete_tags`:

1. **The documented `tag` option was never read.** Declared in the argument spec
   and documented since 1.38.0 as the list of tags to delete, but
   `module.params["tag"]` appears nowhere in the module.
2. **The keys from `kvp` were collected as single-element tuples** and
   intersected with a list of key strings, so the intersection was always empty
   — no change reported, nothing deleted.
3. **Iterating `module.params["kvp"]` raised `TypeError` when only `tag` was
   given**, because `kvp` is `None` then. So the documented usage crashed rather
   than quietly doing nothing, which is the `MODULE FAILURE` above.

Removal now works on keys: `tag` names them, or failing that the keys of `kvp`
with their values ignored, so the same list that created the tags can remove
them. Only keys the volume actually carries are sent, which makes a second run a
no-op, and the whole set goes in one call rather than one per key. The delete
goes through `delete_with_context`.

`tag` also gains **`keys` as an alias**, so this module and the new
`purefa_tags` name the same thing the same way. Say if you would rather not
widen the interface and I will drop it.

After the fix, on the same volume:

```
remove by tag : changed=True failed=False
remove by kvp : changed=True failed=False
tags left     : []
```

plus a second removal reporting no change — `ok=11 changed=5 failed=0`.

**A note on the unit tests.** The one existing test for `delete_tags` passed
against the broken code *for the wrong reason*: the comparison could never
match, so "no change" was the only outcome it could produce. It is now joined by
six tests the old code cannot pass. I checked them against master's module and
should be straight about what that showed — most failed on the patch target
(`delete_with_context` not existing there) rather than on behaviour, so the
hardware run above is the real evidence, not the unit-test run.

##### Volumes, and the supersession warning

`purefa_tags` now covers `volume` as well (REST 2.2, the same `_tags_batch`
write as every type except the array), and `volume` joins the set whose
`copyable` is compared. `purefa_volume_tags` warns on every run:

```
purefa_volume_tags is superseded by purefa_tags, which manages tags on volumes
and every other taggable resource. Use purefa_tags with resource_type: volume
from now on. This module still works and will be deprecated in a future release.
```

Verified on hardware — tagging a volume, flipping `copyable`, and removing a tag
each run twice and settle, and then **`purefa_volume_tags` reports no change
against the tags `purefa_tags` wrote**, which is the check that matters while
both exist. The warning is asserted from the play rather than eyeballed.
`ok=17 changed=5 failed=0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
