### PR TITLE
feat(purefa_info): Add software and support subsets, directory quotas and replication throughput

### DIFF
--- a/changelogs/fragments/1056_purefa_info_read_only_endpoints.yaml
+++ b/changelogs/fragments/1056_purefa_info_read_only_endpoints.yaml
@@ -1,0 +1,14 @@
+minor_changes:
+  - purefa_info - Add C(software) subset, reporting software versions, the patch
+    catalogue and upgrade installation steps.
+  - purefa_info - Add C(support) subset, reporting support diagnostics and a
+    summary of the system manifest.
+  - purefa_info - Report per-directory quotas, and the directory user and group
+    quotas and listings, in the C(filesystems) subset.
+  - purefa_info - Report replication throughput and lag in the C(replication)
+    subset, covering pod replica links, pods, protection groups and snapshot
+    transfers.
+bugfixes:
+  - purefa_info - Fix the C(admins) subset, and therefore C(all), crashing on an
+    array whose administrators have no public key. The field is null by default
+    and the SDK raises rather than returning None.

--- a/plugins/modules/purefa_info.py
+++ b/plugins/modules/purefa_info.py
@@ -883,31 +883,37 @@ def generate_clients_dict(array):
 
 
 def generate_admin_dict(array):
+    """Return the array's administrators
+
+    Every field here is read through getattr, because the SDK models raise
+    AttributeError for anything the array returned as null rather than giving
+    back None. An admin with no public key - which is every admin by default -
+    used to take the whole gather down with it, and a remote user whose role
+    comes back as an empty reference did the same on role.name.
+    """
     admin_info = {}
     admins = list(array.get_admins().items)
     for admin in admins:
         admin_name = admin.name
         admin_info[admin_name] = {
-            "public_key": admin.public_key,
-            "local": admin.is_local,
-            "role": admin.role.name,
-            "locked": admin.locked,
+            "public_key": getattr(admin, "public_key", None),
+            "local": getattr(admin, "is_local", None),
+            "role": getattr(getattr(admin, "role", None), "name", None),
+            "locked": getattr(admin, "locked", None),
             "lockout_remaining": getattr(admin, "lockout_remaining", None),
         }
-        if hasattr(admin.api_token, "expires_at"):
-            if admin.api_token.expires_at:
-                admin_info[admin_name]["token_expires"] = datetime.fromtimestamp(
-                    admin.api_token.expires_at / 1000
+        token = getattr(admin, "api_token", None)
+        for field, key in (
+            ("expires_at", "token_expires"),
+            ("created_at", "token_created"),
+        ):
+            stamp = getattr(token, field, None)
+            if stamp:
+                admin_info[admin_name][key] = datetime.fromtimestamp(
+                    stamp / 1000
                 ).strftime("%Y-%m-%d %H:%M:%S")
-        else:
-            admin_info[admin_name]["token_expires"] = None
-        if hasattr(admin.api_token, "created_at"):
-            if admin.api_token.created_at:
-                admin_info[admin_name]["token_created"] = datetime.fromtimestamp(
-                    admin.api_token.created_at / 1000
-                ).strftime("%Y-%m-%d %H:%M:%S")
-        else:
-            admin_info[admin_name]["token_created"] = None
+            else:
+                admin_info[admin_name][key] = None
     return admin_info
 
 

--- a/plugins/modules/purefa_info.py
+++ b/plugins/modules/purefa_info.py
@@ -36,7 +36,7 @@ options:
         admins, volumes, snapshots, pods, replication, vgroups, offload, apps,
         arrays, certs, kmip, clients, policies, dir_snaps, filesystems,
         alerts, virtual_machines, subscriptions, realms, fleet, presets,
-        workloads and tgroups.
+        workloads, tgroups, software and support.
     type: list
     elements: str
     required: false
@@ -95,6 +95,7 @@ from ansible_collections.everpure.flasharray.plugins.module_utils.version import
 )
 
 from datetime import datetime
+import json
 import time
 
 SEC_TO_DAY = 86400000
@@ -124,6 +125,12 @@ CONTEXT_API_VERSION = "2.38"
 QUOTA_API_VERSION = "2.42"
 TAGS_API_VERSION = "2.39"
 TGROUP_API_VERSION = "2.54"
+# The support and software read endpoints each arrived separately
+SOFTWARE_STEPS_API_VERSION = "2.2"
+SOFTWARE_VERSIONS_API_VERSION = "2.9"
+SOFTWARE_PATCHES_API_VERSION = "2.17"
+SUPPORT_DIAGS_API_VERSION = "2.36"
+SUPPORT_MANIFEST_API_VERSION = "2.51"
 
 
 def _is_cbs(array):
@@ -3290,6 +3297,119 @@ def generate_realms_dict(array, performance):
     return realms_info
 
 
+def generate_software_dict(array, api_version):
+    """Return the software versions, patch catalogue and upgrade history
+
+    Each of the three endpoints arrived in a different release, so each is
+    guarded on its own rather than the newest of the three.
+    """
+    software_info = {"versions": {}, "patches": {}, "installation_steps": {}}
+    if LooseVersion(SOFTWARE_VERSIONS_API_VERSION) <= LooseVersion(api_version):
+        res = array.get_software_versions()
+        if res.status_code == 200:
+            for version in list(res.items):
+                software_info["versions"][version.name] = {
+                    "version": getattr(version, "version", None),
+                    "release_family": getattr(version, "release_family", None),
+                    "details": getattr(version, "details", None),
+                    "upgrade_hops": getattr(version, "upgrade_hops", None),
+                }
+    if LooseVersion(SOFTWARE_PATCHES_API_VERSION) <= LooseVersion(api_version):
+        res = array.get_software_patches_catalog()
+        if res.status_code == 200:
+            for patch in list(res.items):
+                software_info["patches"][patch.name] = {
+                    "description": getattr(patch, "description", None),
+                    "details": getattr(patch, "details", None),
+                    "status": getattr(patch, "status", None),
+                    "progress": getattr(patch, "progress", None),
+                    "alert_code": getattr(patch, "alert_code", None),
+                    "ha_reduction_required": getattr(
+                        patch, "ha_reduction_required", None
+                    ),
+                }
+    if LooseVersion(SOFTWARE_STEPS_API_VERSION) <= LooseVersion(api_version):
+        res = array.get_software_installation_steps()
+        if res.status_code == 200:
+            for step in list(res.items):
+                # steps repeat their name across upgrades, so key on the id
+                software_info["installation_steps"][step.id] = {
+                    "name": getattr(step, "name", None),
+                    "description": getattr(step, "description", None),
+                    "details": getattr(step, "details", None),
+                    "status": getattr(step, "status", None),
+                    "hop_version": getattr(step, "hop_version", None),
+                    "installation": getattr(
+                        getattr(step, "installation", None), "name", None
+                    ),
+                    "start_time": getattr(step, "start_time", None),
+                    "end_time": getattr(step, "end_time", None),
+                    "checks": [
+                        {
+                            "name": getattr(check, "name", None),
+                            "details": getattr(check, "details", None),
+                        }
+                        for check in (getattr(step, "checks", None) or [])
+                    ],
+                }
+    return software_info
+
+
+def generate_support_dict(array, api_version):
+    """Return support diagnostics and a summary of the system manifest
+
+    The manifest comes back as a single JSON document of tens of kilobytes -
+    42KB on the array this was written against. Reporting it whole would weigh
+    down every gather that asks for everything, so the useful header fields are
+    pulled out and the bulk left behind.
+    """
+    support_info = {"diagnostics": {}, "manifest": {}}
+    if LooseVersion(SUPPORT_DIAGS_API_VERSION) <= LooseVersion(api_version):
+        res = array.get_support_diagnostics_details()
+        if res.status_code == 200:
+            for diag in list(res.items):
+                support_info["diagnostics"][getattr(diag, "test_name", "unknown")] = {
+                    "test_type": getattr(diag, "test_type", None),
+                    "severity": getattr(diag, "severity", None),
+                    "result_details": getattr(diag, "result_details", None),
+                }
+    if LooseVersion(SUPPORT_MANIFEST_API_VERSION) <= LooseVersion(api_version):
+        res = array.get_support_system_manifest()
+        if res.status_code == 200:
+            item = next(iter(list(res.items)), None)
+            raw = getattr(item, "system_manifest", None) if item else None
+            manifest = {}
+            if isinstance(raw, str):
+                try:
+                    manifest = json.loads(raw)
+                except ValueError:
+                    manifest = {}
+            elif isinstance(raw, dict):
+                manifest = raw
+            for field in (
+                "manifest_version",
+                "manifest_source",
+                "product_family",
+                "purity_version",
+                "array_name",
+                "appliance_id",
+                "domain",
+                "time_zone",
+                "timestamp",
+            ):
+                support_info["manifest"][field] = manifest.get(field)
+            support_info["manifest"]["licensed_features"] = manifest.get(
+                "licensed_features"
+            )
+            # the component inventory is the bulk of the document - report how
+            # much there is rather than all of it
+            components = manifest.get("components")
+            if isinstance(components, (list, dict)):
+                support_info["manifest"]["component_count"] = len(components)
+            support_info["manifest"]["raw_length"] = len(raw) if raw else 0
+    return support_info
+
+
 def main():
     argument_spec = purefa_argument_spec()
     argument_spec.update(
@@ -3335,6 +3455,8 @@ def main():
         "presets",
         "workloads",
         "tgroups",
+        "software",
+        "support",
     )
     subset_test = (test in valid_subsets for test in subset)
     if not all(subset_test):
@@ -3439,6 +3561,10 @@ def main():
         "tgroups" in subset or "all" in subset
     ):
         info["tgroups"] = generate_tgroups_dict(array)
+    if "software" in subset or "all" in subset:
+        info["software"] = generate_software_dict(array, api_version)
+    if "support" in subset or "all" in subset:
+        info["support"] = generate_support_dict(array, api_version)
     module.exit_json(changed=False, purefa_info=info)
 
 

--- a/plugins/modules/purefa_info.py
+++ b/plugins/modules/purefa_info.py
@@ -131,6 +131,13 @@ SOFTWARE_VERSIONS_API_VERSION = "2.9"
 SOFTWARE_PATCHES_API_VERSION = "2.17"
 SUPPORT_DIAGS_API_VERSION = "2.36"
 SUPPORT_MANIFEST_API_VERSION = "2.51"
+# Directory user and group quotas, and the directory identity views,
+# arrived together with the local users and groups they report on
+DIR_IDENTITY_API_VERSION = "2.44"
+# Replication throughput and lag, each on its own release
+REPL_LAG_API_VERSION = "2.2"
+PGROUP_REPL_PERF_API_VERSION = "2.1"
+SNAP_TRANSFER_API_VERSION = "2.0"
 
 
 def _is_cbs(array):
@@ -3416,6 +3423,218 @@ def generate_support_dict(array, api_version):
     return support_info
 
 
+def _plain(value):
+    """Reduce an SDK model to primitives
+
+    An SDK model cannot be serialised into a module result - exit_json rejects
+    it as a value of unknown type - and the replication endpoints nest them
+    several fields deep: a replica link's lag is an object of its own, and each
+    of a pod's replication rates is an object carrying to, from and total. So
+    anything that is not already a primitive is walked and turned into plain
+    dicts, lists and numbers. A reference is reduced to its name, which is what
+    the rest of this module reports for one.
+    """
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, (list, tuple)):
+        return [_plain(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _plain(item) for key, item in value.items()}
+    fields = getattr(type(value), "__fields__", None)
+    if not fields:
+        return str(value)
+    if set(fields) == {"id", "name"} or set(fields) == {"name"}:
+        return getattr(value, "name", None)
+    out = {}
+    for field in fields:
+        try:
+            out[field] = _plain(getattr(value, field))
+        except AttributeError:
+            # the model raises for anything the array returned as null
+            out[field] = None
+    return out
+
+
+def _directory_key(reference):
+    """The directory a quota or identity row belongs to
+
+    The reference names a directory as "<filesystem>:<directory>", which is how
+    the filesystems dict is nested, so both halves are handed back.
+    """
+    name = getattr(reference, "name", None)
+    if not name or ":" not in name:
+        return None, None
+    filesystem, directory = name.split(":", 1)
+    return filesystem, directory
+
+
+def add_directory_quotas(array, files_info, api_version):
+    """Add quota and identity detail to the directories already reported
+
+    Nothing here is reachable from the directory itself - each is a separate
+    listing keyed by a directory reference - so the rows are matched back onto
+    the filesystems dict rather than fetched per directory.
+    """
+
+    def slot(reference, key):
+        filesystem, directory = _directory_key(reference)
+        if not filesystem:
+            return None
+        entry = files_info.get(filesystem, {}).get("directories", {}).get(directory)
+        if entry is None:
+            return None
+        return entry.setdefault(key, [])
+
+    res = array.get_directory_quotas()
+    if res.status_code == 200:
+        for quota in list(res.items):
+            target = slot(getattr(quota, "directory", None), "quotas")
+            if target is None:
+                continue
+            target.append(
+                {
+                    "path": getattr(quota, "path", None),
+                    "quota_limit": getattr(quota, "quota_limit", None),
+                    "usage": getattr(quota, "usage", None),
+                    "percentage_used": getattr(quota, "percentage_used", None),
+                    "enabled": getattr(quota, "enabled", None),
+                    "enforced": getattr(quota, "enforced", None),
+                    "rule_name": getattr(quota, "rule_name", None),
+                    "policy": getattr(getattr(quota, "policy", None), "name", None),
+                }
+            )
+    if LooseVersion(DIR_IDENTITY_API_VERSION) > LooseVersion(api_version):
+        return
+    for getter, key, subject in (
+        (array.get_directory_user_quotas, "user_quotas", "user"),
+        (array.get_directory_group_quotas, "group_quotas", "group"),
+    ):
+        res = getter()
+        if res.status_code != 200:
+            continue
+        for quota in list(res.items):
+            target = slot(getattr(quota, "directory", None), key)
+            if target is None:
+                continue
+            target.append(
+                {
+                    subject: getattr(getattr(quota, subject, None), "name", None),
+                    "quota": getattr(quota, "quota", None),
+                    "usage": getattr(quota, "usage", None),
+                }
+            )
+    for getter, key in (
+        (array.get_directories_users, "users"),
+        (array.get_directories_groups, "groups"),
+    ):
+        res = getter()
+        if res.status_code != 200:
+            continue
+        for row in list(res.items):
+            target = slot(getattr(row, "directory", None), key)
+            if target is None:
+                continue
+            target.append(getattr(row, "name", None))
+
+
+def generate_replication_perf_dict(array, api_version):
+    """Return replication throughput and lag
+
+    purefa_info reports what is replicating but not how fast, or how far
+    behind. None of it is on the objects themselves - each is its own listing.
+    """
+    perf = {
+        "pod_replica_links": {},
+        "pods": {},
+        "protection_groups": {},
+        "snapshot_transfers": {},
+    }
+    if LooseVersion(REPL_LAG_API_VERSION) <= LooseVersion(api_version):
+        res = array.get_pod_replica_links_lag()
+        if res.status_code == 200:
+            for link in list(res.items):
+                perf["pod_replica_links"][link.id] = {
+                    "local_pod": getattr(
+                        _plain(getattr(link, "local_pod", None)), "name", None
+                    ),
+                    "remote_pod": getattr(
+                        _plain(getattr(link, "remote_pod", None)), "name", None
+                    ),
+                    "direction": _plain(getattr(link, "direction", None)),
+                    "status": _plain(getattr(link, "status", None)),
+                    "lag": _plain(getattr(link, "lag", None)),
+                    "recovery_point": _plain(getattr(link, "recovery_point", None)),
+                }
+        res = array.get_pod_replica_links_performance_replication()
+        if res.status_code == 200:
+            for link in list(res.items):
+                entry = perf["pod_replica_links"].setdefault(link.id, {})
+                entry["bytes_per_sec_from_remote"] = getattr(
+                    link, "bytes_per_sec_from_remote", None
+                )
+                entry["bytes_per_sec_to_remote"] = getattr(
+                    link, "bytes_per_sec_to_remote", None
+                )
+                entry["bytes_per_sec_total"] = getattr(
+                    link, "bytes_per_sec_total", None
+                )
+        res = array.get_pods_performance_replication()
+        if res.status_code == 200:
+            for row in list(res.items):
+                pod = _plain(getattr(row, "pod", None))
+                if not pod:
+                    continue
+                # each of these is an object carrying to, from and total
+                perf["pods"][pod] = {
+                    field: _plain(getattr(row, field, None))
+                    for field in (
+                        "total_bytes_per_sec",
+                        "continuous_bytes_per_sec",
+                        "periodic_bytes_per_sec",
+                        "resync_bytes_per_sec",
+                        "sync_bytes_per_sec",
+                    )
+                }
+    if LooseVersion(PGROUP_REPL_PERF_API_VERSION) <= LooseVersion(api_version):
+        res = array.get_protection_groups_performance_replication()
+        if res.status_code == 200:
+            for row in list(res.items):
+                if _plain(getattr(row, "name", None)):
+                    perf["protection_groups"][row.name] = {
+                        "bytes_per_sec": _plain(getattr(row, "bytes_per_sec", None)),
+                    }
+        res = array.get_remote_protection_group_snapshots_transfer()
+        if res.status_code == 200:
+            for snap in list(res.items):
+                if _plain(getattr(snap, "name", None)):
+                    perf["snapshot_transfers"][snap.name] = {
+                        "remote": True,
+                        "progress": _plain(getattr(snap, "progress", None)),
+                        "data_transferred": _plain(
+                            getattr(snap, "data_transferred", None)
+                        ),
+                        "completed": _plain(getattr(snap, "completed", None)),
+                    }
+    if LooseVersion(SNAP_TRANSFER_API_VERSION) <= LooseVersion(api_version):
+        res = array.get_volume_snapshots_transfer()
+        if res.status_code == 200:
+            for snap in list(res.items):
+                if _plain(getattr(snap, "name", None)):
+                    perf["snapshot_transfers"][snap.name] = {
+                        "remote": False,
+                        "progress": _plain(getattr(snap, "progress", None)),
+                        "data_transferred": _plain(
+                            getattr(snap, "data_transferred", None)
+                        ),
+                        "physical_bytes_written": getattr(
+                            snap, "physical_bytes_written", None
+                        ),
+                        "completed": _plain(getattr(snap, "completed", None)),
+                        "started": _plain(getattr(snap, "started", None)),
+                    }
+    return perf
+
+
 def main():
     argument_spec = purefa_argument_spec()
     argument_spec.update(
@@ -3531,6 +3750,7 @@ def main():
         info["google_offload"] = generate_google_offload_dict(array)
     if "filesystems" in subset or "all" in subset:
         info["filesystems"] = generate_filesystems_dict(array, performance)
+        add_directory_quotas(array, info["filesystems"], api_version)
     if "policies" in subset or "all" in subset:
         user_map = bool(LooseVersion(NFS_USER_MAP_VERSION) <= LooseVersion(api_version))
         quota = bool(LooseVersion(DIR_QUOTA_API_VERSION) <= LooseVersion(api_version))
@@ -3567,6 +3787,10 @@ def main():
         "tgroups" in subset or "all" in subset
     ):
         info["tgroups"] = generate_tgroups_dict(array)
+    if "replication" in subset or "all" in subset:
+        info["replication_performance"] = generate_replication_perf_dict(
+            array, api_version
+        )
     if "software" in subset or "all" in subset:
         info["software"] = generate_software_dict(array, api_version)
     if "support" in subset or "all" in subset:

--- a/tests/unit/plugins/modules/test_purefa_info.py
+++ b/tests/unit/plugins/modules/test_purefa_info.py
@@ -2088,3 +2088,177 @@ class TestGenerateClientsDict:
         assert result["api-client-1"]["enabled"] is True
         assert result["api-client-1"]["client_id"] == "client-id-123"
         assert result["api-client-1"]["access_token_ttl_seconds"] == 3600
+
+
+class TestGenerateSoftwareDict:
+    """Tests for generate_software_dict"""
+
+    @staticmethod
+    def _array(**responses):
+        array = Mock()
+        for name, value in responses.items():
+            getattr(array, name).return_value = value
+        return array
+
+    def test_each_endpoint_guarded_on_its_own_version(self):
+        """Test an array too old for one endpoint still reports the others
+
+        The three endpoints arrived in 2.2, 2.9 and 2.17, so a single floor
+        would hide data an older array can serve.
+        """
+        from plugins.modules.purefa_info import generate_software_dict
+
+        step = Mock()
+        step.id = "step-1"
+        step.name = "pre-upgrade check"
+        step.status = "finished"
+        step.checks = []
+        array = self._array(
+            get_software_installation_steps=Mock(status_code=200, items=[step]),
+        )
+
+        out = generate_software_dict(array, "2.2")
+
+        assert list(out["installation_steps"]) == ["step-1"]
+        assert out["versions"] == {}
+        assert out["patches"] == {}
+        array.get_software_versions.assert_not_called()
+        array.get_software_patches_catalog.assert_not_called()
+
+    def test_all_three_on_a_current_array(self):
+        from plugins.modules.purefa_info import generate_software_dict
+
+        version = Mock()
+        version.name = "6.10.6"
+        patch = Mock()
+        patch.name = "patch-1"
+        step = Mock()
+        step.id = "step-1"
+        step.checks = []
+        array = self._array(
+            get_software_versions=Mock(status_code=200, items=[version]),
+            get_software_patches_catalog=Mock(status_code=200, items=[patch]),
+            get_software_installation_steps=Mock(status_code=200, items=[step]),
+        )
+
+        out = generate_software_dict(array, "2.56")
+
+        assert list(out["versions"]) == ["6.10.6"]
+        assert list(out["patches"]) == ["patch-1"]
+        assert list(out["installation_steps"]) == ["step-1"]
+
+    def test_installation_steps_keyed_on_id_not_name(self):
+        """Step names repeat across upgrades, so the id is the key"""
+        from plugins.modules.purefa_info import generate_software_dict
+
+        first, second = Mock(), Mock()
+        first.id, second.id = "a", "b"
+        first.name = second.name = "pre-upgrade check"
+        first.checks = second.checks = []
+        array = self._array(
+            get_software_installation_steps=Mock(
+                status_code=200, items=[first, second]
+            ),
+        )
+
+        out = generate_software_dict(array, "2.2")
+
+        assert sorted(out["installation_steps"]) == ["a", "b"]
+
+    def test_a_failed_read_is_not_fatal(self):
+        from plugins.modules.purefa_info import generate_software_dict
+
+        array = self._array(
+            get_software_versions=Mock(status_code=400, items=[]),
+            get_software_patches_catalog=Mock(status_code=400, items=[]),
+            get_software_installation_steps=Mock(status_code=400, items=[]),
+        )
+
+        out = generate_software_dict(array, "2.56")
+
+        assert out == {"versions": {}, "patches": {}, "installation_steps": {}}
+
+
+class TestGenerateSupportDict:
+    """Tests for generate_support_dict"""
+
+    @staticmethod
+    def _manifest_array(raw):
+        array = Mock()
+        item = Mock()
+        item.system_manifest = raw
+        array.get_support_system_manifest.return_value = Mock(
+            status_code=200, items=[item]
+        )
+        array.get_support_diagnostics_details.return_value = Mock(
+            status_code=200, items=[]
+        )
+        return array
+
+    def test_manifest_is_summarised_not_copied(self):
+        """Test only the header fields are kept
+
+        The manifest is a single JSON document of tens of kilobytes, so the
+        bulk of it is deliberately left out.
+        """
+        import json
+
+        from plugins.modules.purefa_info import generate_support_dict
+
+        raw = json.dumps(
+            {
+                "manifest_version": 1.0,
+                "purity_version": "6.10.6",
+                "array_name": "arrayone",
+                "components": [{"a": 1}, {"b": 2}, {"c": 3}],
+                "licensed_features": ["one"],
+                "space": {"lots": "of detail"},
+            }
+        )
+
+        out = generate_support_dict(self._manifest_array(raw), "2.56")
+
+        assert out["manifest"]["purity_version"] == "6.10.6"
+        assert out["manifest"]["array_name"] == "arrayone"
+        assert out["manifest"]["component_count"] == 3
+        assert out["manifest"]["raw_length"] == len(raw)
+        # the bulky members are not carried through
+        assert "components" not in out["manifest"]
+        assert "space" not in out["manifest"]
+
+    def test_unparseable_manifest_does_not_raise(self):
+        from plugins.modules.purefa_info import generate_support_dict
+
+        out = generate_support_dict(self._manifest_array("not json at all"), "2.56")
+
+        assert out["manifest"]["purity_version"] is None
+        assert out["manifest"]["raw_length"] == len("not json at all")
+
+    def test_manifest_skipped_on_an_older_array(self):
+        from plugins.modules.purefa_info import generate_support_dict
+
+        array = self._manifest_array("{}")
+
+        out = generate_support_dict(array, "2.40")
+
+        assert out["manifest"] == {}
+        array.get_support_system_manifest.assert_not_called()
+        array.get_support_diagnostics_details.assert_called_once()
+
+    def test_diagnostics_keyed_on_test_name(self):
+        from plugins.modules.purefa_info import generate_support_dict
+
+        diag = Mock()
+        diag.test_name = "a check"
+        diag.test_type = "hardware"
+        diag.severity = "info"
+        diag.result_details = "all good"
+        array = Mock()
+        array.get_support_diagnostics_details.return_value = Mock(
+            status_code=200, items=[diag]
+        )
+        array.get_support_system_manifest.return_value = Mock(status_code=200, items=[])
+
+        out = generate_support_dict(array, "2.56")
+
+        assert out["diagnostics"]["a check"]["severity"] == "info"

--- a/tests/unit/plugins/modules/test_purefa_info.py
+++ b/tests/unit/plugins/modules/test_purefa_info.py
@@ -2262,3 +2262,213 @@ class TestGenerateSupportDict:
         out = generate_support_dict(array, "2.56")
 
         assert out["diagnostics"]["a check"]["severity"] == "info"
+
+
+class FakeModel:
+    """Stands in for an SDK model, including its habit of raising on null"""
+
+    def __init__(self, **fields):
+        self._values = fields
+        type(self).__fields__ = {k: None for k in fields}
+
+    def __getattr__(self, name):
+        values = self.__dict__.get("_values", {})
+        if name in values:
+            if values[name] is _NULL:
+                raise AttributeError(name)
+            return values[name]
+        raise AttributeError(name)
+
+
+_NULL = object()
+
+
+class TestPlain:
+    """Tests for _plain, which keeps SDK objects out of the module result"""
+
+    def test_primitives_pass_through(self):
+        from plugins.modules.purefa_info import _plain
+
+        for value in (None, True, 1, 1.5, "text"):
+            assert _plain(value) == value
+
+    def test_nested_model_becomes_a_dict(self):
+        """An SDK model cannot be serialised, so it has to be walked
+
+        This is what took the replication gather down twice: lag is an object,
+        and so is each of a pod's replication rates.
+        """
+        from plugins.modules.purefa_info import _plain
+
+        lag = FakeModel(avg=1500, max=1500)
+
+        assert _plain(lag) == {"avg": 1500, "max": 1500}
+
+    def test_reference_reduces_to_its_name(self):
+        from plugins.modules.purefa_info import _plain
+
+        assert _plain(FakeModel(id="abc", name="pod1")) == "pod1"
+
+    def test_null_field_does_not_raise(self):
+        from plugins.modules.purefa_info import _plain
+
+        assert _plain(FakeModel(avg=1, max=_NULL)) == {"avg": 1, "max": None}
+
+    def test_lists_are_walked(self):
+        from plugins.modules.purefa_info import _plain
+
+        out = _plain([FakeModel(id="a", name="one"), FakeModel(id="b", name="two")])
+
+        assert out == ["one", "two"]
+
+
+class TestDirectoryQuotas:
+    """Tests for add_directory_quotas"""
+
+    @staticmethod
+    def _files_info():
+        return {"fs1": {"directories": {"dir1": {}}}}
+
+    @staticmethod
+    def _array(**responses):
+        array = Mock()
+        empty = Mock(status_code=200, items=[])
+        for name in (
+            "get_directory_quotas",
+            "get_directory_user_quotas",
+            "get_directory_group_quotas",
+            "get_directories_users",
+            "get_directories_groups",
+        ):
+            getattr(array, name).return_value = responses.get(name, empty)
+        return array
+
+    def test_quota_lands_on_the_right_directory(self):
+        """A quota names its directory as filesystem colon directory"""
+        from plugins.modules.purefa_info import add_directory_quotas
+
+        quota = Mock()
+        quota.directory = Mock()
+        quota.directory.name = "fs1:dir1"
+        quota.quota_limit = 1024
+        quota.usage = 512
+        quota.policy = Mock()
+        quota.policy.name = "pol1"
+        files_info = self._files_info()
+
+        add_directory_quotas(
+            self._array(get_directory_quotas=Mock(status_code=200, items=[quota])),
+            files_info,
+            "2.56",
+        )
+
+        quotas = files_info["fs1"]["directories"]["dir1"]["quotas"]
+        assert len(quotas) == 1
+        assert quotas[0]["quota_limit"] == 1024
+        assert quotas[0]["policy"] == "pol1"
+
+    def test_a_quota_for_an_unreported_directory_is_dropped(self):
+        """Test a row that matches nothing does not invent a directory"""
+        from plugins.modules.purefa_info import add_directory_quotas
+
+        quota = Mock()
+        quota.directory = Mock()
+        quota.directory.name = "otherfs:otherdir"
+        files_info = self._files_info()
+
+        add_directory_quotas(
+            self._array(get_directory_quotas=Mock(status_code=200, items=[quota])),
+            files_info,
+            "2.56",
+        )
+
+        assert files_info == {"fs1": {"directories": {"dir1": {}}}}
+
+    def test_identity_views_skipped_on_an_older_array(self):
+        """The user and group views arrived in 2.44"""
+        from plugins.modules.purefa_info import add_directory_quotas
+
+        array = self._array()
+
+        add_directory_quotas(array, self._files_info(), "2.40")
+
+        array.get_directory_quotas.assert_called_once()
+        array.get_directory_user_quotas.assert_not_called()
+        array.get_directories_users.assert_not_called()
+
+
+class TestReplicationPerf:
+    """Tests for generate_replication_perf_dict"""
+
+    @staticmethod
+    def _array(**responses):
+        array = Mock()
+        empty = Mock(status_code=200, items=[])
+        for name in (
+            "get_pod_replica_links_lag",
+            "get_pod_replica_links_performance_replication",
+            "get_pods_performance_replication",
+            "get_protection_groups_performance_replication",
+            "get_remote_protection_group_snapshots_transfer",
+            "get_volume_snapshots_transfer",
+        ):
+            getattr(array, name).return_value = responses.get(name, empty)
+        return array
+
+    def test_lag_and_throughput_merge_on_the_same_link(self):
+        """Both come from separate endpoints keyed on the same link id"""
+        from plugins.modules.purefa_info import generate_replication_perf_dict
+
+        lag = Mock()
+        lag.id = "link-1"
+        lag.lag = FakeModel(avg=1500, max=1500)
+        throughput = Mock()
+        throughput.id = "link-1"
+        throughput.bytes_per_sec_total = 99
+
+        out = generate_replication_perf_dict(
+            self._array(
+                get_pod_replica_links_lag=Mock(status_code=200, items=[lag]),
+                get_pod_replica_links_performance_replication=Mock(
+                    status_code=200, items=[throughput]
+                ),
+            ),
+            "2.56",
+        )
+
+        link = out["pod_replica_links"]["link-1"]
+        assert link["lag"] == {"avg": 1500, "max": 1500}
+        assert link["bytes_per_sec_total"] == 99
+
+    def test_local_and_remote_transfers_are_distinguished(self):
+        from plugins.modules.purefa_info import generate_replication_perf_dict
+
+        remote, local = Mock(), Mock()
+        remote.name = "pgroup.snap"
+        local.name = "vol.snap"
+
+        out = generate_replication_perf_dict(
+            self._array(
+                get_remote_protection_group_snapshots_transfer=Mock(
+                    status_code=200, items=[remote]
+                ),
+                get_volume_snapshots_transfer=Mock(status_code=200, items=[local]),
+            ),
+            "2.56",
+        )
+
+        assert out["snapshot_transfers"]["pgroup.snap"]["remote"] is True
+        assert out["snapshot_transfers"]["vol.snap"]["remote"] is False
+
+    def test_a_failed_read_is_not_fatal(self):
+        from plugins.modules.purefa_info import generate_replication_perf_dict
+
+        array = self._array(
+            get_pod_replica_links_lag=Mock(status_code=400, items=[]),
+            get_pods_performance_replication=Mock(status_code=400, items=[]),
+        )
+
+        out = generate_replication_perf_dict(array, "2.56")
+
+        assert out["pod_replica_links"] == {}
+        assert out["pods"] == {}


### PR DESCRIPTION
##### SUMMARY

First instalment of the read-only endpoint review: `purefa_info` could not report
on 74 read-only endpoints the SDK exposes. This covers two new subsets, two
clusters of additions to existing ones, and one crash found on the way.

**Partial by intent** — the remaining additions are listed at the end and will
follow in a second PR.

##### Two new subsets

- **`software`** — `software_versions`, `software_patches_catalog` and
  `software_installation_steps`. Those arrived in 2.9, 2.17 and 2.2, so each is
  guarded on its own version rather than the newest of the three; an older array
  can still serve the steps. Steps are keyed on **id**, not name, because a name
  like `pre-upgrade check` repeats for every upgrade hop.
- **`support`** — `support_diagnostics_details`, and a **summary** of
  `support_system_manifest`.

The manifest needs explaining. It comes back as one JSON document — **42 KB** on
the array this was written against — and `gather_subset: all` would carry all of
it. So the header fields are pulled out (purity version, array name, appliance
id, product family, licensed features), plus a count of the component inventory
and the length of the original. Anything more is a deliberate call for a caller
to make against the API.

On this array, software versions, the patch catalogue and support diagnostics all
answer 200 with **no items**, so those three field shapes come from the SDK
models rather than live data. Worth knowing if their output ever looks wrong.

##### Directory quotas and identity, into `filesystems`

`directory_quotas`, and behind a 2.44 guard the user and group quotas and the
directory user and group listings. None of it hangs off the directory itself —
each is a separate listing keyed by a directory reference of the form
`<filesystem>:<directory>` — so rows are matched back onto the directories
already reported rather than fetched one directory at a time. A row naming a
directory that is not in the gather is dropped rather than inventing an entry.

This pairs with `purefa_localuser` and `purefa_localgroup` from #1054: there is
finally something to report on.

##### Replication throughput and lag, into `replication`

A new `replication_performance` key: pod replica link lag and bytes per second,
per-pod replication rates, per-protection-group rates, and snapshot transfer
progress for local and remote snapshots. The module could already say *what* was
replicating, but not how fast or how far behind.

**These endpoints nest SDK models several fields deep** — a replica link's `lag`
is an object with its own average and maximum, and each of a pod's replication
rates is an object carrying to, from and total. Ansible cannot serialise an SDK
model (`exit_json` rejects it as a value of unknown type), and it took two failed
gathers before I stopped fixing that field by field. Everything now goes through
one recursive `_plain` helper, which also reduces a reference to its name and
converts the models' raise-on-null habit into `None`.

##### A crash found on the way: `gather_subset: all` was broken

`gather_subset=admins`, and therefore `all`, failed outright on this array **on
upstream master**, before any of these changes:

```
File "purefa_info.py", line 884, in generate_admin_dict
File "admin_v_2_54.py", line 115, in __getattribute__
  raise AttributeError
```

`admin.public_key` is null for every admin that has not been given one — which
is every admin by default — and the SDK raises `AttributeError` rather than
returning `None`. The same trap fixed in `purefa_network` for #1029. A remote
user's `role` also comes back as an empty reference, so `role.name` raised too.
Every field is now read through `getattr`.

I only found this because `all` was the obvious way to check the new subsets had
not broken anything, and it was already broken.

##### ISSUE TYPE

- Feature Pull Request
- Bugfix Pull Request

##### COMPONENT NAME

purefa_info

##### ADDITIONAL INFORMATION

Verified on hardware throughout:

```
software.installation_steps: 20     support.manifest: 42262 chars -> 12 keys
directories with quotas: 2          pod_replica_links: 1   pods: 5
protection_groups: 11               snapshot_transfers: 42

TASK [The manifest summary must carry the header fields, not the bulk] ***  ok
TASK [minimum must not carry software or support] ***  ok
TASK [A replica link must carry both lag and throughput] ***  ok
TASK [Gathering all must still work and carry the new keys] ***  ok
```

Read-only throughout — nothing on the array was changed. 75 unit tests pass
(11 new), covering the `_plain` flattener including nested models, references
and null fields; the quota-to-directory matching including a row that matches
nothing; the per-endpoint version guards; and that a failed read is not fatal.
`ansible-test sanity --local` is clean.

##### Still to come, in a second PR

From the agreed list: the per-array performance breakdowns (`hosts`,
`host_groups`, `volumes`, `pods`, `directories`), `protection_groups_space`,
`arrays_cache`, `arrays_performance_by_link`, `admins_api_tokens`,
`certificates_uses` and `certificate_groups_uses`, `policies_members` and
`policies_network_access_members`, the membership views (`pods_arrays`,
`pods_members`, `volumes_protection_groups`, `remote_pods`, `remote_realms` and
their tags), `virtual_machine_volume_snapshots`, `fleets_fleet_key` and
`topology_groups_arrays`.

**Two items from the agreed list should be dropped, and I would not add them:**

- **`alerts_events`** cannot be gathered in bulk — it answers
  `Must specify an alert ID(s)`, so reporting it means one call per alert.
- **`snmp_agents_mib`** returns `500 Unidentified internal error` on this array,
  so there is nothing to verify against.

The `*_performance_by_array` endpoints also carry ~44 fields each
(`volumes_performance_by_array` is 49 objects × 44 fields), so they want a
selected field list rather than a wholesale copy — worth agreeing before I write
it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
