### PR TITLE
update purefa_inventory to retain drive serial, interface pcie slot, and move temp_sensors to the proper dict

### DIFF
--- a/changelogs/fragments/1057_purefa_inventory_serial_slot.yaml
+++ b/changelogs/fragments/1057_purefa_inventory_serial_slot.yaml
@@ -1,0 +1,20 @@
+minor_changes:
+  - purefa_inventory - Temperature sensors are now reported in the ``temperature`` dict, which was
+    previously initialized but always empty. They continue to be reported in ``controllers`` as
+    well, so this is a backwards compatible addition.
+  - purefa_inventory - Adds ``slot`` to each interface in the ``interfaces`` subset, reporting the
+    PCI Express slot number that hosts the port.
+  - purefa_inventory - Reports ``nvram_bay`` hardware components in the ``drives`` subset, so NVRAM
+    devices carry ``identify_enabled`` and ``serial`` like every other drive. nvram_bays are
+    already captured in this dict by the ``array.get_drives()`` pass but would otherwise be missing
+    the ``identify_enabled`` key.
+
+deprecated_features:
+  - purefa_inventory - Reporting temperature sensors in the ``controllers`` dict is deprecated and
+    will be removed in the next major release. Use the ``temperature`` dict instead, so that
+    ``controllers`` holds only controllers.
+
+bugfixes:
+  - purefa_inventory - Fixes the ``serial`` and ``identify_enabled`` of each drive being dropped
+    from the ``drives`` subset, as the ``array.get_drives()`` pass overwrote the value already
+    collected from the matching ``drive_bay`` hardware component.

--- a/changelogs/fragments/10??_purefa_inventory_serial_slot.yaml
+++ b/changelogs/fragments/10??_purefa_inventory_serial_slot.yaml
@@ -1,0 +1,9 @@
+breaking_changes:
+  - purefa_inventory - Temperature sensors are now reported in the ``temperature`` dict rather than mixed into ``controllers``, so that ``controllers`` holds only controllers. The ``temperature`` dict was previously always empty.
+
+minor_changes:
+  - purefa_inventory - Add ``slot`` to each interface in the ``interfaces`` subset, reporting the PCI Express slot number that hosts the port.
+  - purefa_inventory - Report ``nvram_bay`` hardware components in the ``drives`` subset, so NVRAM devices carry ``identify_enabled`` and ``serial`` like every other drive. nvram_bays are already captured in this dict by the array.get_drives() pass but would otherwise be missing the ``identify_enabled`` key.
+
+bugfixes:
+  - purefa_inventory - Fixed the ``serial`` and ``identify_enabled`` of each drive being dropped from the ``drives`` subset, as the ``array.get_drives()`` pass overwrote the value already collected from the matching ``drive_bay`` hardware component

--- a/changelogs/fragments/10??_purefa_inventory_serial_slot.yaml
+++ b/changelogs/fragments/10??_purefa_inventory_serial_slot.yaml
@@ -1,9 +1,0 @@
-breaking_changes:
-  - purefa_inventory - Temperature sensors are now reported in the ``temperature`` dict rather than mixed into ``controllers``, so that ``controllers`` holds only controllers. The ``temperature`` dict was previously initialized but always empty.
-
-minor_changes:
-  - purefa_inventory - Adds ``slot`` to each interface in the ``interfaces`` subset, reporting the PCI Express slot number that hosts the port.
-  - purefa_inventory - Reports ``nvram_bay`` hardware components in the ``drives`` subset, so NVRAM devices carry ``identify_enabled`` and ``serial`` like every other drive. nvram_bays are already captured in this dict by the ``array.get_drives()`` pass but would otherwise be missing the ``identify_enabled`` key.
-
-bugfixes:
-  - purefa_inventory - Fixes the ``serial`` and ``identify_enabled`` of each drive being dropped from the ``drives`` subset, as the ``array.get_drives()`` pass overwrote the value already collected from the matching ``drive_bay`` hardware component.

--- a/changelogs/fragments/10??_purefa_inventory_serial_slot.yaml
+++ b/changelogs/fragments/10??_purefa_inventory_serial_slot.yaml
@@ -1,9 +1,9 @@
 breaking_changes:
-  - purefa_inventory - Temperature sensors are now reported in the ``temperature`` dict rather than mixed into ``controllers``, so that ``controllers`` holds only controllers. The ``temperature`` dict was previously always empty.
+  - purefa_inventory - Temperature sensors are now reported in the ``temperature`` dict rather than mixed into ``controllers``, so that ``controllers`` holds only controllers. The ``temperature`` dict was previously initialized but always empty.
 
 minor_changes:
-  - purefa_inventory - Add ``slot`` to each interface in the ``interfaces`` subset, reporting the PCI Express slot number that hosts the port.
-  - purefa_inventory - Report ``nvram_bay`` hardware components in the ``drives`` subset, so NVRAM devices carry ``identify_enabled`` and ``serial`` like every other drive. nvram_bays are already captured in this dict by the array.get_drives() pass but would otherwise be missing the ``identify_enabled`` key.
+  - purefa_inventory - Adds ``slot`` to each interface in the ``interfaces`` subset, reporting the PCI Express slot number that hosts the port.
+  - purefa_inventory - Reports ``nvram_bay`` hardware components in the ``drives`` subset, so NVRAM devices carry ``identify_enabled`` and ``serial`` like every other drive. nvram_bays are already captured in this dict by the ``array.get_drives()`` pass but would otherwise be missing the ``identify_enabled`` key.
 
 bugfixes:
-  - purefa_inventory - Fixed the ``serial`` and ``identify_enabled`` of each drive being dropped from the ``drives`` subset, as the ``array.get_drives()`` pass overwrote the value already collected from the matching ``drive_bay`` hardware component
+  - purefa_inventory - Fixes the ``serial`` and ``identify_enabled`` of each drive being dropped from the ``drives`` subset, as the ``array.get_drives()`` pass overwrote the value already collected from the matching ``drive_bay`` hardware component.

--- a/plugins/modules/purefa_inventory.py
+++ b/plugins/modules/purefa_inventory.py
@@ -93,7 +93,10 @@ def generate_new_hardware_dict(array):
                 "status": component.status,
                 "temperature": component.temperature,
             }
-        if component.type == "drive_bay":
+        if component.type in [
+            "drive_bay",
+            "nvram_bay"
+        ]:
             hw_info["drives"][component_name] = {
                 "status": component.status,
                 "identify_enabled": component.identify_enabled,

--- a/plugins/modules/purefa_inventory.py
+++ b/plugins/modules/purefa_inventory.py
@@ -95,7 +95,7 @@ def generate_new_hardware_dict(array):
             }
         if component.type in [
             "drive_bay",
-            "nvram_bay"
+            "nvram_bay",
         ]:
             hw_info["drives"][component_name] = {
                 "status": component.status,

--- a/plugins/modules/purefa_inventory.py
+++ b/plugins/modules/purefa_inventory.py
@@ -118,6 +118,7 @@ def generate_new_hardware_dict(array):
                 "tx_fault": None,
                 "tx_power": None,
                 "voltage": None,
+                "slot": getattr(component, "slot", None),
             }
         if component.type == "power_supply":
             hw_info["power"][component_name] = {

--- a/plugins/modules/purefa_inventory.py
+++ b/plugins/modules/purefa_inventory.py
@@ -89,10 +89,16 @@ def generate_new_hardware_dict(array):
                 "status": component.status,
             }
         if component.type == "temp_sensor":
-            hw_info["temperature"][component_name] = {
+            sensor = {
                 "status": component.status,
                 "temperature": component.temperature,
             }
+            hw_info["temperature"][component_name] = sensor
+            # Temperature sensors are also reported in ``controllers``, where
+            # they have always been, so that this remains a backwards
+            # compatible addition. Deprecated - to be removed from
+            # ``controllers`` in the next major release.
+            hw_info["controllers"][component_name] = dict(sensor)
         if component.type in [
             "drive_bay",
             "nvram_bay",

--- a/plugins/modules/purefa_inventory.py
+++ b/plugins/modules/purefa_inventory.py
@@ -130,14 +130,21 @@ def generate_new_hardware_dict(array):
     drives = list(array.get_drives().items)
     for drive in drives:
         drive_name = drive.name
-        hw_info["drives"][drive_name] = {
-            "capacity": drive.capacity,
-            "capacity_installed": getattr(drive, "capacity_installed", drive.capacity),
-            "status": drive.status,
-            "protocol": getattr(drive, "protocol", None),
-            "details": getattr(drive, "details", None),
-            "type": drive.type,
-        }
+        drive_info = hw_info["drives"].setdefault(
+            drive_name, {"identify_enabled": None, "serial": None}
+        )
+        drive_info.update(
+            {
+                "capacity": drive.capacity,
+                "capacity_installed": getattr(
+                    drive, "capacity_installed", drive.capacity
+                ),
+                "status": drive.status,
+                "protocol": getattr(drive, "protocol", None),
+                "details": getattr(drive, "details", None),
+                "type": drive.type,
+            }
+        )
     api_version = array.get_rest_version()
     if LooseVersion(SFP_API_VERSION) <= LooseVersion(api_version):
         port_details = list(array.get_network_interfaces_port_details().items)

--- a/plugins/modules/purefa_inventory.py
+++ b/plugins/modules/purefa_inventory.py
@@ -89,7 +89,7 @@ def generate_new_hardware_dict(array):
                 "status": component.status,
             }
         if component.type == "temp_sensor":
-            hw_info["controllers"][component_name] = {
+            hw_info["temperature"][component_name] = {
                 "status": component.status,
                 "temperature": component.temperature,
             }

--- a/tests/unit/plugins/modules/test_purefa_inventory.py
+++ b/tests/unit/plugins/modules/test_purefa_inventory.py
@@ -189,10 +189,11 @@ class TestGenerateHardwareDict:
 
         result = generate_new_hardware_dict(mock_array)
 
-        assert "controllers" in result
-        assert "CT0.TMP0" in result["controllers"]
-        assert result["controllers"]["CT0.TMP0"]["status"] == "ok"
-        assert result["controllers"]["CT0.TMP0"]["temperature"] == 45
+        assert "temperature" in result
+        assert "CT0.TMP0" in result["temperature"]
+        assert result["temperature"]["CT0.TMP0"]["status"] == "ok"
+        assert result["temperature"]["CT0.TMP0"]["temperature"] == 45
+        assert "CT0.TMP0" not in result["controllers"]
 
     @patch("plugins.modules.purefa_inventory.LooseVersion")
     def test_generates_drive_bay_dict(self, mock_lv):
@@ -225,6 +226,119 @@ class TestGenerateHardwareDict:
         assert result["drives"]["SH0.BAY0"]["serial"] == "BAY001"
 
     @patch("plugins.modules.purefa_inventory.LooseVersion")
+    def test_drive_serial_survives_drives_pass(self, mock_lv):
+        """Test drive_bay serial is merged with, not overwritten by, get_drives"""
+        mock_array = Mock()
+
+        mock_array.get_rest_version.return_value = "2.10"
+        mock_lv.side_effect = float
+
+        mock_bay = Mock()
+        mock_bay.name = "CH0.BAY0"
+        mock_bay.type = "drive_bay"
+        mock_bay.status = "ok"
+        mock_bay.identify_enabled = False
+        mock_bay.serial = "PFMUH2348229B"
+
+        mock_hardware_response = Mock()
+        mock_hardware_response.items = [mock_bay]
+        mock_array.get_hardware.return_value = mock_hardware_response
+
+        # Same name as the drive_bay component above - both passes touch this entry
+        mock_drive = Mock()
+        mock_drive.name = "CH0.BAY0"
+        mock_drive.capacity = 2250000000000
+        mock_drive.capacity_installed = 2250000000000
+        mock_drive.status = "healthy"
+        mock_drive.protocol = "NVMe"
+        mock_drive.details = None
+        mock_drive.type = "SSD"
+
+        mock_drives_response = Mock()
+        mock_drives_response.items = [mock_drive]
+        mock_array.get_drives.return_value = mock_drives_response
+
+        result = generate_new_hardware_dict(mock_array)
+
+        # From the drive_bay pass
+        assert result["drives"]["CH0.BAY0"]["serial"] == "PFMUH2348229B"
+        assert result["drives"]["CH0.BAY0"]["identify_enabled"] is False
+        # From the get_drives pass
+        assert result["drives"]["CH0.BAY0"]["capacity"] == 2250000000000
+        assert result["drives"]["CH0.BAY0"]["type"] == "SSD"
+        assert result["drives"]["CH0.BAY0"]["status"] == "healthy"
+
+    @patch("plugins.modules.purefa_inventory.LooseVersion")
+    def test_generates_nvram_bay_dict(self, mock_lv):
+        """Test generating hardware dict with nvram_bay components"""
+        mock_array = Mock()
+
+        mock_array.get_rest_version.return_value = "2.10"
+        mock_lv.side_effect = float
+
+        mock_nvram_bay = Mock()
+        mock_nvram_bay.name = "CH0.NVB0"
+        mock_nvram_bay.type = "nvram_bay"
+        mock_nvram_bay.status = "ok"
+        mock_nvram_bay.identify_enabled = False
+        mock_nvram_bay.serial = None
+
+        mock_hardware_response = Mock()
+        mock_hardware_response.items = [mock_nvram_bay]
+        mock_array.get_hardware.return_value = mock_hardware_response
+
+        mock_drive = Mock()
+        mock_drive.name = "CH0.NVB0"
+        mock_drive.capacity = 7516192768
+        mock_drive.capacity_installed = 7516192768
+        mock_drive.status = "healthy"
+        mock_drive.protocol = "NVMe"
+        mock_drive.details = None
+        mock_drive.type = "NVRAM"
+
+        mock_drives_response = Mock()
+        mock_drives_response.items = [mock_drive]
+        mock_array.get_drives.return_value = mock_drives_response
+
+        result = generate_new_hardware_dict(mock_array)
+
+        assert "CH0.NVB0" in result["drives"]
+        assert result["drives"]["CH0.NVB0"]["identify_enabled"] is False
+        assert result["drives"]["CH0.NVB0"]["serial"] is None
+        assert result["drives"]["CH0.NVB0"]["type"] == "NVRAM"
+
+    @patch("plugins.modules.purefa_inventory.LooseVersion")
+    def test_drive_without_hardware_component(self, mock_lv):
+        """Test a drive with no matching bay component still has serial keys"""
+        mock_array = Mock()
+
+        mock_array.get_rest_version.return_value = "2.10"
+        mock_lv.side_effect = float
+
+        mock_hardware_response = Mock()
+        mock_hardware_response.items = []
+        mock_array.get_hardware.return_value = mock_hardware_response
+
+        mock_drive = Mock()
+        mock_drive.name = "CH9.BAY9"
+        mock_drive.capacity = 0
+        mock_drive.capacity_installed = 0
+        mock_drive.status = "unused"
+        mock_drive.protocol = None
+        mock_drive.details = None
+        mock_drive.type = "-"
+
+        mock_drives_response = Mock()
+        mock_drives_response.items = [mock_drive]
+        mock_array.get_drives.return_value = mock_drives_response
+
+        result = generate_new_hardware_dict(mock_array)
+
+        assert result["drives"]["CH9.BAY9"]["serial"] is None
+        assert result["drives"]["CH9.BAY9"]["identify_enabled"] is None
+        assert result["drives"]["CH9.BAY9"]["capacity"] == 0
+
+    @patch("plugins.modules.purefa_inventory.LooseVersion")
     def test_generates_network_interfaces_dict(self, mock_lv):
         """Test generating hardware dict with various network port types"""
         mock_array = Mock()
@@ -237,12 +351,14 @@ class TestGenerateHardwareDict:
         mock_fc_port.type = "fc_port"
         mock_fc_port.status = "ok"
         mock_fc_port.speed = 32000000000
+        mock_fc_port.slot = 3
 
         mock_eth_port = Mock()
         mock_eth_port.name = "CT0.ETH0"
         mock_eth_port.type = "eth_port"
         mock_eth_port.status = "ok"
         mock_eth_port.speed = 10000000000
+        mock_eth_port.slot = None
 
         mock_hardware_response = Mock()
         mock_hardware_response.items = [mock_fc_port, mock_eth_port]
@@ -259,6 +375,53 @@ class TestGenerateHardwareDict:
         assert result["interfaces"]["CT0.FC0"]["type"] == "fc_port"
         assert "CT0.ETH0" in result["interfaces"]
         assert result["interfaces"]["CT0.ETH0"]["type"] == "eth_port"
+
+    @patch("plugins.modules.purefa_inventory.LooseVersion")
+    def test_reports_interface_slot(self, mock_lv):
+        """Test slot is reported for PCIe-hosted ports and null for onboard ones"""
+        mock_array = Mock()
+
+        mock_array.get_rest_version.return_value = "2.10"
+        mock_lv.side_effect = float
+
+        mock_onboard_eth = Mock()
+        mock_onboard_eth.name = "CT0.ETH0"
+        mock_onboard_eth.type = "eth_port"
+        mock_onboard_eth.status = "ok"
+        mock_onboard_eth.speed = 0
+        mock_onboard_eth.slot = None
+
+        mock_card_eth = Mock()
+        mock_card_eth.name = "CT0.ETH8"
+        mock_card_eth.type = "eth_port"
+        mock_card_eth.status = "ok"
+        mock_card_eth.speed = 25000000000
+        mock_card_eth.slot = 1
+
+        mock_fc_port = Mock()
+        mock_fc_port.name = "CT0.FC0"
+        mock_fc_port.type = "fc_port"
+        mock_fc_port.status = "ok"
+        mock_fc_port.speed = 32000000000
+        mock_fc_port.slot = 3
+
+        mock_hardware_response = Mock()
+        mock_hardware_response.items = [
+            mock_onboard_eth,
+            mock_card_eth,
+            mock_fc_port,
+        ]
+        mock_array.get_hardware.return_value = mock_hardware_response
+
+        mock_drives_response = Mock()
+        mock_drives_response.items = []
+        mock_array.get_drives.return_value = mock_drives_response
+
+        result = generate_new_hardware_dict(mock_array)
+
+        assert result["interfaces"]["CT0.ETH8"]["slot"] == 1
+        assert result["interfaces"]["CT0.FC0"]["slot"] == 3
+        assert result["interfaces"]["CT0.ETH0"]["slot"] is None
 
     @patch("plugins.modules.purefa_inventory.LooseVersion")
     def test_generates_power_supply_dict(self, mock_lv):
@@ -307,6 +470,7 @@ class TestGenerateHardwareDict:
         mock_fc_port.type = "fc_port"
         mock_fc_port.status = "ok"
         mock_fc_port.speed = 32000000000
+        mock_fc_port.slot = 3
 
         mock_hardware_response = Mock()
         mock_hardware_response.items = [mock_fc_port]

--- a/tests/unit/plugins/modules/test_purefa_inventory.py
+++ b/tests/unit/plugins/modules/test_purefa_inventory.py
@@ -193,7 +193,39 @@ class TestGenerateHardwareDict:
         assert "CT0.TMP0" in result["temperature"]
         assert result["temperature"]["CT0.TMP0"]["status"] == "ok"
         assert result["temperature"]["CT0.TMP0"]["temperature"] == 45
-        assert "CT0.TMP0" not in result["controllers"]
+        # Still reported in controllers as well - deprecated, but removing it
+        # would be a breaking change to the returned inventory
+        assert result["controllers"]["CT0.TMP0"]["status"] == "ok"
+        assert result["controllers"]["CT0.TMP0"]["temperature"] == 45
+
+    @patch("plugins.modules.purefa_inventory.LooseVersion")
+    def test_temp_sensor_dicts_are_independent(self, mock_lv):
+        """Test the duplicated sensor entries are not the same object"""
+        mock_array = Mock()
+
+        mock_array.get_rest_version.return_value = "2.10"
+        mock_lv.side_effect = float
+
+        mock_temp = Mock()
+        mock_temp.name = "CT0.TMP0"
+        mock_temp.type = "temp_sensor"
+        mock_temp.status = "ok"
+        mock_temp.temperature = 45
+
+        mock_hardware_response = Mock()
+        mock_hardware_response.items = [mock_temp]
+        mock_array.get_hardware.return_value = mock_hardware_response
+
+        mock_drives_response = Mock()
+        mock_drives_response.items = []
+        mock_array.get_drives.return_value = mock_drives_response
+
+        result = generate_new_hardware_dict(mock_array)
+
+        assert (
+            result["temperature"]["CT0.TMP0"] is not result["controllers"]["CT0.TMP0"]
+        )
+        assert result["temperature"]["CT0.TMP0"] == result["controllers"]["CT0.TMP0"]
 
     @patch("plugins.modules.purefa_inventory.LooseVersion")
     def test_generates_drive_bay_dict(self, mock_lv):


### PR DESCRIPTION
##### SUMMARY
`purefa_inventory` did not expose two pieces of hardware data that the REST API makes available, which forced our NetBox hardware-sync workflows to bypass the collection and call the raw API directly. This exposes both, and (via a breaking change) fixes a related issue with temp sensors that irks me.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
module: purefa_inventory

##### ADDITIONAL INFORMATION
1. The slot on which an interface or other module lives is provided by the hardware API but isn't returned by `purefa_inventory`. This is useful for syncing our FlashArray hardware data to netbox to correlate specific interfaces to the pcie expansion cards on which they reside. I would also add slot to the direct_compress_accelerator card for the same reason (tracking which pcie slot it's in), but since the DCA is not returned by `purefa_inventory` today–and doesn't fit neatly into one of the existing `hw_info` dicts–I wasn't sure where to place it, so I left it out for now. I'll have to keep consuming the API directly for tracking the DCA unless someone has thoughts about where to place it in the `purefa_inventory` module's output, but that's a "me" problem until I get some input there on where it should go.

2. The drives section contains what appears to be an unintentional regression where the `status`, `identify_enabled`, and `serial` attributes are written into the `hw_info` dict but then discarded by the `for drive in drives` pass setting a dict literal in the same location. The PR fixes this by doing a merge instead; also, it adds the `nvram_bay` to the component pass. The `nvram_bay`s are returned by the `get_drives` pass but if we don't add it to the components pass in conjunction with the merge fix for the drives issue, then those items would still be missing their `identify_enabled` attribute (as they do today). The merge defaults to None for the `identify_enabled` and `serial` in case `get_drives` ever returns another type not accounted for in the components pass in a similar fashion to the `nvram_bay` issue I just described.

3. Temperature readings are moved into the already existing `hw_info['temperature']` dict instead of the `hw_info['controllers']` dict. As it stands today the temperatures dict is returned by purefa_inventory but is always empty and the temp sensors are all in controllers instead. Not sure why that is but this should fix that. Note that **this would be a breaking change** for anyone's code that was expecting the temperature readings in the `controllers` dict, though, so please let me know if I should divorce this change from this PR to prevent introducing a breaking change the collection isn't ready for.

I had `claude` help with the updates to the module's tests covering the changes.

Before: `drives` entries carry no serial, temp readings are in `controllers` while `temperatures` is empty, and `interfaces` don't have their associated slot number:
```
(debug)> p task_vars['purefa_inventory']['purefa_inv']
{'chassis': {'CH0': {...},
 'controllers': {'CH0.TMP0': {'status': 'ok', 'temperature': 30},
                 'CT0': {'identify_enabled': False,
                         'model': 'FA-X20R4',
                         'serial': 'SERIAL_NUMBER',
                         'status': 'ok'},
                 'CT0.TMP0': {'status': 'ok', 'temperature': 42},
                 'CT0.TMP1': {'status': 'ok', 'temperature': 43},
                 'CT0.TMP11': {'status': 'ok', 'temperature': 37},
...
},
'drives': {'CH0.BAY0': {'capacity': 2250000000000,
                         'capacity_installed': 2250000000000,
                         'details': None,
                         'protocol': 'NVMe',
                         'status': 'healthy',
                         'type': 'SSD'},
...
            'CH0.NVB0': {'capacity': 7516192768,
                         'capacity_installed': 7516192768,
                         'details': None,
                         'protocol': 'NVMe',
                         'status': 'healthy',
                         'type': 'NVRAM'},
...
},
 'fans': {...},
 'interfaces': {'CT0.ETH0': {'connector_type': None,
                             'rx_los': None,
                             'rx_power': None,
                             'speed': 0,
                             'static': {},
                             'status': 'ok',
                             'temperature': None,
                             'tx_bias': None,
                             'tx_fault': None,
                             'tx_power': None,
                             'type': 'eth_port',
                             'voltage': None},
...
},
 'power': {...},
 'temperature': {}}
```

After: drive `serial` and `identify_enabled` status is preserved, `identify_enabled` also now present on NVRAM devices, `slot` reported on `interfaces`, and temp sensor readings relocated to `temperatures`:
```{'chassis': {'CH0': {...}},
 'controllers': {'CT0': {'identify_enabled': False,
                         'model': 'FA-X90R4',
                         'serial': 'SERIAL_NUMBER',
                         'status': 'ok'},
                 'CT1': {'identify_enabled': False,
                         'model': 'FA-X90R4',
                         'serial': 'SERIAL_NUMBER',
                         'status': 'ok'}},
 'drives': {'CH0.BAY0': {'capacity': 36600000000000,
                         'capacity_installed': 36600000000000,
                         'details': None,
                         'identify_enabled': False,
                         'protocol': 'NVMe',
                         'serial': 'PFMUH26021715',
                         'status': 'healthy',
                         'type': 'SSD'},
...
                 'CH0.NVB0': {'capacity': 7516192768,
                         'capacity_installed': 7516192768,
                         'details': None,
                         'identify_enabled': False,
                         'protocol': 'NVMe',
                         'serial': None,
                         'status': 'healthy',
                         'type': 'NVRAM'},
...
},
 'fans': {...},
 'interfaces': {'CT0.ETH0': {'connector_type': None,
                             'rx_los': None,
                             'rx_power': None,
                             'slot': None,
                             'speed': 0,
                             'static': {},
                             'status': 'ok',
                             'temperature': None,
                             'tx_bias': None,
                             'tx_fault': None,
                             'tx_power': None,
                             'type': 'eth_port',
                             'voltage': None},
...
                'CT0.ETH10': {'connector_type': None,
                              'interface_type': 'eth',
                              'rx_los': None,
                              'rx_power': None,
                              'slot': 1,
                              'speed': 100000000000,
                              'static': {'connector_type': 'No separable '
                                                           'connector',
                                         'encoding': None,
                                         'extended_identifier': 'Power Class 1 '
                                                                '(1.5 W max.), '
                                                                'No CDR in Tx, '
                                                                'No CDR in Rx',
                                         'fc_link_lengths': None,
                                         'fc_speeds': None,
                                         'fc_technology': None,
                                         'fc_transmission_media': None,
                                         'identifier': 'QSFP28',
                                         'link_length': 'Copper Cable: 3 m, '
                                                        'Attenuation at 2.5 '
                                                        'GHz: 5 dB, '
                                                        'Attenuation at 5.0 '
                                                        'GHz: 8 dB',
                                         'rate_identifier': 'No Rate Selection '
                                                            'Support',
                                         'signaling_rate': '25750 MBd',
                                         'vendor_date_code': '240812',
                                         'vendor_name': 'Arista Networks',
                                         'vendor_oui': '00-1C-73',
                                         'vendor_part_number': 'CAB-Q-Q-100G-3M',
                                         'vendor_serial_number': 'Q240408220020-B',
                                         'wavelength': None},
                              'status': 'ok',
                              'temperature': None,
                              'tx_bias': None,
                              'tx_fault': None,
                              'tx_power': None,
                              'type': 'eth_port',
                              'voltage': None},
...
},
 'power': {...},
 'temperature': {'CH0.TMP0': {'status': 'ok', 'temperature': 21},
                 'CT0.TMP0': {'status': 'ok', 'temperature': 35},
                 'CT0.TMP1': {'status': 'ok', 'temperature': 38},
...
}}
```