### PR TITLE
purefa_inventory - report unclassified hardware in an other dict

### DIFF
--- a/changelogs/fragments/1059_purefa_inventory_other_hardware.yaml
+++ b/changelogs/fragments/1059_purefa_inventory_other_hardware.yaml
@@ -1,0 +1,8 @@
+minor_changes:
+  - purefa_inventory - Hardware components without a dedicated dict of their own are now reported in
+    a new ``other`` dict, keyed by component name and carrying the component ``type``, rather than
+    being dropped from the inventory. This covers ``direct_compress_accelerator``, ``sas_module``
+    and ``storage_shelf``, as well as any component type the array reports in future.
+  - purefa_inventory - The contents of the ``other`` dict are not stable. A component reported there
+    may be moved into a dedicated dict in a future release, so match on the ``type`` key rather than
+    assuming a component stays in ``other``.

--- a/plugins/modules/purefa_inventory.py
+++ b/plugins/modules/purefa_inventory.py
@@ -21,6 +21,12 @@ short_description: Collect information from Everpure FlashArray
 version_added: '1.0.0'
 description:
   - Collect hardware inventory information from a Everpure Flasharray
+  - Hardware components that do not have a dedicated dict of their own are
+    reported in the C(other) dict, keyed by component name, with the component
+    type in the C(type) key.
+  - The contents of C(other) are not stable. A component reported there may be
+    moved into a dedicated dict in a future release, so match on the C(type)
+    key rather than assuming a component stays in C(other).
 author:
   - Everpure ansible Team (@sdodsley) <pure-ansible-team@everpuredata.com>
 extends_documentation_fragment:
@@ -66,6 +72,7 @@ def generate_new_hardware_dict(array):
         "power": {},
         "chassis": {},
         "temperature": {},
+        "other": {},
     }
     components = list(array.get_hardware().items)
     for component in components:
@@ -77,18 +84,18 @@ def generate_new_hardware_dict(array):
                 "model": component.model,
                 "identify_enabled": component.identify_enabled,
             }
-        if component.type == "controller":
+        elif component.type == "controller":
             hw_info["controllers"][component_name] = {
                 "status": component.status,
                 "serial": component.serial,
                 "model": component.model,
                 "identify_enabled": component.identify_enabled,
             }
-        if component.type == "cooling":
+        elif component.type == "cooling":
             hw_info["fans"][component_name] = {
                 "status": component.status,
             }
-        if component.type == "temp_sensor":
+        elif component.type == "temp_sensor":
             sensor = {
                 "status": component.status,
                 "temperature": component.temperature,
@@ -99,7 +106,7 @@ def generate_new_hardware_dict(array):
             # compatible addition. Deprecated - to be removed from
             # ``controllers`` in the next major release.
             hw_info["controllers"][component_name] = dict(sensor)
-        if component.type in [
+        elif component.type in [
             "drive_bay",
             "nvram_bay",
         ]:
@@ -108,7 +115,7 @@ def generate_new_hardware_dict(array):
                 "identify_enabled": component.identify_enabled,
                 "serial": getattr(component, "serial", None),
             }
-        if component.type in [
+        elif component.type in [
             "sas_port",
             "fc_port",
             "eth_port",
@@ -129,12 +136,33 @@ def generate_new_hardware_dict(array):
                 "voltage": None,
                 "slot": getattr(component, "slot", None),
             }
-        if component.type == "power_supply":
+        elif component.type == "power_supply":
             hw_info["power"][component_name] = {
                 "status": component.status,
                 "voltage": getattr(component, "voltage", None),
                 "serial": getattr(component, "serial", None),
                 "model": getattr(component, "model", None),
+            }
+        else:
+            # Any component type without a dedicated dict of its own, so that
+            # hardware the array reports is not silently dropped - see #1058.
+            # Which fields a given component populates is not known in
+            # advance, and the SDK models raise AttributeError rather than
+            # returning None for the ones it does not, so every field here is
+            # read with a default. A direct_compress_accelerator, for example,
+            # populates only status, slot and index.
+            hw_info["other"][component_name] = {
+                "type": component.type,
+                "status": getattr(component, "status", None),
+                "slot": getattr(component, "slot", None),
+                "index": getattr(component, "index", None),
+                "model": getattr(component, "model", None),
+                "serial": getattr(component, "serial", None),
+                "identify_enabled": getattr(component, "identify_enabled", None),
+                "speed": getattr(component, "speed", None),
+                "temperature": getattr(component, "temperature", None),
+                "voltage": getattr(component, "voltage", None),
+                "details": getattr(component, "details", None),
             }
     drives = list(array.get_drives().items)
     for drive in drives:

--- a/tests/unit/plugins/modules/test_purefa_inventory.py
+++ b/tests/unit/plugins/modules/test_purefa_inventory.py
@@ -560,3 +560,215 @@ class TestGenerateHardwareDict:
         assert result["interfaces"]["CT0.FC0"]["tx_fault"] is False
         assert result["interfaces"]["CT0.FC0"]["tx_power"] == -2.5
         assert result["interfaces"]["CT0.FC0"]["voltage"] == 3.3
+
+
+class FakeComponent:
+    """Stand-in for the SDK's Hardware model.
+
+    py-pure-client models raise AttributeError for any field the array
+    returned as null rather than returning None. Mock objects do not, so a
+    bare attribute access on a field a component leaves unpopulated looks
+    fine under Mock and crashes against a real array.
+    """
+
+    def __init__(self, **fields):
+        self._fields = fields
+
+    def __getattr__(self, name):
+        value = self._fields.get(name)
+        if value is None:
+            raise AttributeError(name)
+        return value
+
+
+class TestOtherHardware:
+    """Tests for the other dict - issue #1058"""
+
+    @patch("plugins.modules.purefa_inventory.LooseVersion")
+    def test_reports_direct_compress_accelerator(self, mock_lv):
+        """Test a DCA is reported in other rather than dropped"""
+        mock_array = Mock()
+
+        mock_array.get_rest_version.return_value = "2.54"
+        mock_lv.side_effect = float
+
+        # Exactly the payload from issue #1058 - a DCA populates only index,
+        # slot, status and type; every other field comes back null
+        mock_dca = FakeComponent(
+            name="CT0.DCA4",
+            type="direct_compress_accelerator",
+            status="ok",
+            slot=4,
+            index=4,
+            details=None,
+            identify_enabled=None,
+            model=None,
+            serial=None,
+            speed=None,
+            temperature=None,
+            voltage=None,
+        )
+
+        mock_hardware_response = Mock()
+        mock_hardware_response.items = [mock_dca]
+        mock_array.get_hardware.return_value = mock_hardware_response
+
+        mock_drives_response = Mock()
+        mock_drives_response.items = []
+        mock_array.get_drives.return_value = mock_drives_response
+
+        # 2.54 is past SFP_API_VERSION, so the port details pass runs
+        mock_array.get_network_interfaces_port_details.return_value = Mock(items=[])
+
+        result = generate_new_hardware_dict(mock_array)
+
+        assert "CT0.DCA4" in result["other"]
+        dca = result["other"]["CT0.DCA4"]
+        assert dca["type"] == "direct_compress_accelerator"
+        assert dca["status"] == "ok"
+        assert dca["slot"] == 4
+        assert dca["index"] == 4
+        assert dca["serial"] is None
+        assert dca["identify_enabled"] is None
+        assert dca["model"] is None
+        # and it must not have leaked into any of the other dicts
+        assert result["interfaces"] == {}
+        assert result["controllers"] == {}
+        assert result["drives"] == {}
+
+    @patch("plugins.modules.purefa_inventory.LooseVersion")
+    def test_reports_unknown_component_type(self, mock_lv):
+        """Test a component type the module has never seen is still reported"""
+        mock_array = Mock()
+
+        mock_array.get_rest_version.return_value = "2.54"
+        mock_lv.side_effect = float
+
+        mock_widget = FakeComponent(
+            name="CT0.WIDGET0",
+            type="some_future_component",
+            status="healthy",
+            index=0,
+        )
+
+        mock_hardware_response = Mock()
+        mock_hardware_response.items = [mock_widget]
+        mock_array.get_hardware.return_value = mock_hardware_response
+
+        mock_drives_response = Mock()
+        mock_drives_response.items = []
+        mock_array.get_drives.return_value = mock_drives_response
+
+        # 2.54 is past SFP_API_VERSION, so the port details pass runs
+        mock_array.get_network_interfaces_port_details.return_value = Mock(items=[])
+
+        result = generate_new_hardware_dict(mock_array)
+
+        assert result["other"]["CT0.WIDGET0"]["type"] == "some_future_component"
+        assert result["other"]["CT0.WIDGET0"]["status"] == "healthy"
+        assert result["other"]["CT0.WIDGET0"]["voltage"] is None
+
+    @patch("plugins.modules.purefa_inventory.LooseVersion")
+    def test_known_component_types_stay_out_of_other(self, mock_lv):
+        """Test components with a dedicated dict are not also put in other"""
+        mock_array = Mock()
+
+        mock_array.get_rest_version.return_value = "2.54"
+        mock_lv.side_effect = float
+
+        known = [
+            FakeComponent(
+                name="CH0",
+                type="chassis",
+                status="ok",
+                serial="PCHFS12",
+                model="FA-X20R3",
+                identify_enabled=False,
+            ),
+            FakeComponent(
+                name="CT0",
+                type="controller",
+                status="ok",
+                serial="PCTFS34",
+                model="FA-X20R3",
+                identify_enabled=False,
+            ),
+            FakeComponent(name="CT0.FAN0", type="cooling", status="ok"),
+            FakeComponent(
+                name="CT0.TMP0", type="temp_sensor", status="ok", temperature=45
+            ),
+            FakeComponent(
+                name="CH0.BAY0",
+                type="drive_bay",
+                status="ok",
+                identify_enabled=False,
+                serial="BAY001",
+            ),
+            FakeComponent(
+                name="CH0.NVB0",
+                type="nvram_bay",
+                status="ok",
+                identify_enabled=False,
+            ),
+            FakeComponent(
+                name="CT0.ETH0", type="eth_port", status="ok", speed=10000000000
+            ),
+            FakeComponent(
+                name="CT0.FC0", type="fc_port", status="ok", speed=32000000000, slot=3
+            ),
+            FakeComponent(
+                name="CT0.PWR0",
+                type="power_supply",
+                status="ok",
+                voltage=12,
+                serial="PWR001",
+                model="DS1600",
+            ),
+        ]
+
+        mock_hardware_response = Mock()
+        mock_hardware_response.items = known
+        mock_array.get_hardware.return_value = mock_hardware_response
+
+        mock_drives_response = Mock()
+        mock_drives_response.items = []
+        mock_array.get_drives.return_value = mock_drives_response
+
+        # 2.54 is past SFP_API_VERSION, so the port details pass runs
+        mock_array.get_network_interfaces_port_details.return_value = Mock(items=[])
+
+        result = generate_new_hardware_dict(mock_array)
+
+        assert result["other"] == {}
+        # spot check the components still landed where they belong
+        assert "CH0" in result["chassis"]
+        assert "CT0" in result["controllers"]
+        assert "CT0.FAN0" in result["fans"]
+        assert "CT0.TMP0" in result["temperature"]
+        assert "CH0.BAY0" in result["drives"]
+        assert "CH0.NVB0" in result["drives"]
+        assert "CT0.ETH0" in result["interfaces"]
+        assert "CT0.PWR0" in result["power"]
+
+    @patch("plugins.modules.purefa_inventory.LooseVersion")
+    def test_other_is_always_present(self, mock_lv):
+        """Test other exists even on an array reporting no such components"""
+        mock_array = Mock()
+
+        mock_array.get_rest_version.return_value = "2.54"
+        mock_lv.side_effect = float
+
+        mock_hardware_response = Mock()
+        mock_hardware_response.items = []
+        mock_array.get_hardware.return_value = mock_hardware_response
+
+        mock_drives_response = Mock()
+        mock_drives_response.items = []
+        mock_array.get_drives.return_value = mock_drives_response
+
+        # 2.54 is past SFP_API_VERSION, so the port details pass runs
+        mock_array.get_network_interfaces_port_details.return_value = Mock(items=[])
+
+        result = generate_new_hardware_dict(mock_array)
+
+        assert result["other"] == {}


### PR DESCRIPTION
##### SUMMARY

Fixes #1058

`generate_new_hardware_dict()` only reported the component types it had a dedicated dict for, so anything else `/hardware` returned was silently dropped. That is `direct_compress_accelerator`, which prompted the report, and also `sas_module` and `storage_shelf` - both in the documented type list, neither with a home.

Unclassified components now go into a new `other` dict, keyed by component name and carrying the component `type`, so new hardware types get reported as arrays start returning them rather than needing a module change each time. The chain of independent `if` statements becomes an `if`/`elif`/`else` so the `else` can catch them; the conditions were already mutually exclusive, so nothing about the existing dicts changes, and it no longer tests every component against all seven branches.

Example, for the DCA from the issue:

```yaml
other:
  CT0.DCA4:
    type: direct_compress_accelerator
    status: ok
    slot: 4
    index: 4
    model: null
    serial: null
    identify_enabled: null
    speed: null
    temperature: null
    voltage: null
    details: null
```

**Why a catch-all rather than a dedicated dict per type.** `nvram_bay` is handled by this module but is not in the API's documented type list, so enumerating types will keep losing this race. A catch-all fixes the whole class at once, which is what the issue asks for - all the hardware components, not a subset.

To keep that from becoming a compatibility trap, `other` is documented as unstable in both the module `description` and the changelog: a component reported there may move into a dedicated dict in a future release, and consumers should match on the `type` key. That makes any such promotion a minor change rather than a breaking one.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_inventory

##### ADDITIONAL INFORMATION

**No REST version gate is needed.** `direct_compress_accelerator` becomes a documented type value at REST 2.51 - the SDK carries two generations of the `Hardware` model and that is where the type list flips from the old short forms (`bay`, `ct`, `eth`, `fc`, `tmp`...) to the long ones. But `type` is an unvalidated `Optional[StrictStr]` in both generations, with no enum validator, so the value deserialises at any REST version and the new branch is simply inert on an array that does not report such components. `slot` is likewise present in `hardware_v_2_2`, so #1057 needed no gate either.

**Every field in `other` is read with a `getattr` default.** Which fields a component populates is not knowable in advance, and the SDK models raise `AttributeError` rather than returning `None` for the ones it does not. From the payload in the issue, a DCA populates only `status`, `slot` and `index` - so the bare `component.identify_enabled` pattern the `drive_bay` branch uses would crash on one. That is the trap this fix has to avoid, and there is a test for it.

**Testing.** The DCA test uses the exact payload from the issue, via a `FakeComponent` stand-in that raises `AttributeError` on null fields the way the SDK models do. A plain `Mock` returns `None` instead, which would hide the crash above.

Verified the new tests bite, by reverting the module change and re-running them:

```paste below
FAILED tests/unit/plugins/modules/test_purefa_inventory.py::TestOtherHardware::test_reports_direct_compress_accelerator
FAILED tests/unit/plugins/modules/test_purefa_inventory.py::TestOtherHardware::test_reports_unknown_component_type
FAILED tests/unit/plugins/modules/test_purefa_inventory.py::TestOtherHardware::test_known_component_types_stay_out_of_other
FAILED tests/unit/plugins/modules/test_purefa_inventory.py::TestOtherHardware::test_other_is_always_present
4 failed, 13 deselected
```

Full suite after the fix: `pytest tests/unit` - 2463 passed. `black --check` clean, `yamllint -c .yamllint` clean on the fragment, and `DOCUMENTATION`/`EXAMPLES`/`RETURN` all still parse as YAML after the doc edit.

**Not verified against hardware.** I enumerated a lab array at REST 2.54, which reports 124 components across 9 types - `chassis`, `controller`, `cooling`, `drive_bay`, `eth_port`, `fc_port`, `nvram_bay`, `power_supply`, `temp_sensor` - and confirmed `other` stays empty for all of them. It has no DCA, `sas_module` or `storage_shelf` cards, so those three paths are covered by unit tests only. @meagan-gibbons-exp - if you get a chance, it would be worth confirming the `other` output on the array from the issue before this ships.

Changelog fragment included: `changelogs/fragments/1059_purefa_inventory_other_hardware.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
